### PR TITLE
Allow migrations to skip postgres or mongo or vault

### DIFF
--- a/migrate/2.19-compress.sh
+++ b/migrate/2.19-compress.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+##
+# Create tar ball with the signing & encryption keys,
+# Vault, PostgreSQL and Mongo exports.
+##
+function compress() {
+    echo ... compressing exported files
+
+    mkdir -p circleci_export
+
+    mv $PG_BU $MONGO_BU $KEY_BU $VAULT_BU circleci_export
+    rm -f circleci_export.tar.gz
+    tar cfz circleci_export.tar.gz circleci_export
+
+    rm -rf circleci_export
+}

--- a/migrate/2.19-export.sh
+++ b/migrate/2.19-export.sh
@@ -28,19 +28,18 @@ source 2.19-preflight.sh
 source 2.19-postgres.sh
 source 2.19-mongo.sh
 source 2.19-vault.sh
+source 2.19-key.sh
+source 2.19-compress.sh
 
 # Constants
 DATE=$(date +"%Y-%m-%d-%s")
 MONGO_DATA="/data/circle/mongo"
-MONGO_BU="circleci-mongo-export"
 MONGO_VERSION="3.6.6"
 TMP_MONGO="circle-mongo-export"
-PG_BU="circleci-pg-export"
 PGDATA="/data/circle/postgres/9.5/data"
 PGVERSION="9.5.8"
 TMP_PSQL="circle-postgres-export"
 KEY_BU="circle-data"
-VAULT_BU="circleci-vault"
 
 ARGS="${@:1}"
 
@@ -48,7 +47,10 @@ ARGS="${@:1}"
 
 help_init_options() {
     # Help message for Init menu
-    echo "  -s|--skip-databases           Skip importing Postgres and Mongodb data locally"
+    echo "  -s|--skip-databases           Skip migrating Postgres and Mongodb data"
+    echo "  -p|--skip-postgres            Skip migrating Postgres data"
+    echo "  -m|--skip-mongo               Skip migrating Mongodb data"
+    echo "  -v|--skip-vault               Skip migrating Vault data"
     echo "  -h|--help                     Print help text"
 }
 
@@ -60,7 +62,20 @@ init_options() {
     key="${1}"
     case $key in
         -s|--skip-databases)
-            SKIP_DATABASE_EXPORT="true"
+            SKIP_POSTGRES="true"
+            SKIP_MONGO="true"
+            shift # past argument
+        ;;
+        -p|--skip-postgres)
+            SKIP_POSTGRES="true"
+            shift # past argument
+        ;;
+        -m|--skip-mongo)
+            SKIP_MONGO="true"
+            shift # past argument
+        ;;
+        -v|--skip-vault)
+            SKIP_VAULT="true"
             shift # past argument
         ;;
         -h|--help)
@@ -89,22 +104,31 @@ function circleci_database_export() {
 
     preflight_checks
 
-    if [ ! "$SKIP_DATABASE_EXPORT" = "true" ];
+    if [ ! "$SKIP_MONGO" = "true" ];
     then
+        MONGO_BU="circleci-mongo-export"
         start_mongo
         export_mongo
         check_mongo
         stop_mongo
-
+    fi
+    
+    if [ ! "$SKIP_POSTGRES" = "true" ];
+    then
+        PG_BU="circleci-pg-export"
         start_postgres
         export_postgres
         check_postgres
         stop_postgres
-    else
-        unset PG_BU MONGO_BU # the compress function references these
     fi
 
-    archive_data # archive vault & keys
+    if [ ! "$SKIP_VAULT" = "true" ];
+    then
+        VAULT_BU="circleci-vault"
+        export_vault
+    fi
+
+    export_keys
 
     compress
 

--- a/migrate/2.19-key.sh
+++ b/migrate/2.19-key.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+##
+# CircleCI encryption & signing keys
+##
+function export_keys() {
+    echo ... copying over encryption and signing keys
+
+    mkdir -p $KEY_BU
+
+    cp /data/circle/circleci-encryption-keys/* $KEY_BU
+}

--- a/migrate/2.19-preflight.sh
+++ b/migrate/2.19-preflight.sh
@@ -12,17 +12,17 @@ function preflight_checks() {
         echo "Please run this script as root"
         exit 1
 
-    elif [ -n "$(docker ps | grep circleci-frontend | head -n1 )" ]
+    elif [[ ! "$SKIP_MONGO $SKIP_POSTGRES $SKIP_VAULT" = "true true true" && -n "$(docker ps | grep circleci-frontend | head -n1 )" ]]
     then
         echo "Please shut down CircleCI from the replicated console at https://<YOUR_CIRCLE_URL>:8800 before running this script."
         exit 1
 
-    elif [[ ! "$SKIP_DATABASE_IMPORT" = "true" && -n "$(docker ps | grep mongo | head -n1 )" ]]
+    elif [[ ! "$SKIP_MONGO" = "true" && -n "$(docker ps | grep mongo | head -n1 )" ]]
     then
         echo "Please shut down any other Mongo containers before running this script"
         exit 1
 
-    elif [[ ! "$SKIP_DATABASE_IMPORT" = "true" && -n "$(docker ps | grep -v replicated | grep postgres | head -n1 )" ]]
+    elif [[ ! "$SKIP_POSTGRES" = "true" && -n "$(docker ps | grep -v replicated | grep postgres | head -n1 )" ]]
     then
         echo "Please shut down any other PostgreSQL containers before running this script"
         exit 1

--- a/migrate/2.19-vault.sh
+++ b/migrate/2.19-vault.sh
@@ -1,34 +1,17 @@
 #!/bin/bash
 
 ##
-# Vault
-# CircleCI encryption & signing keys
+# Vault export
 ##
-function archive_data() {
-    echo ... copying over application data
+function export_vault() {
+    echo ... exporting Vault data
 
-    mkdir -p $KEY_BU $VAULT_BU file
+    mkdir -p $VAULT_BU file
 
-    cp /data/circle/circleci-encryption-keys/* $KEY_BU
     rsync -azv /data/circle/contexts-vault/ file/
 
     tar cfz vault-backup.tar.gz file/
     mv vault-backup.tar.gz $VAULT_BU
 
     rm -rf file
-}
-
-##
-# Create tar ball with the keys and Vault, PostgreSQL and Mongo exports
-##
-function compress() {
-    echo ... compressing exported files
-
-    mkdir -p circleci_export
-
-    mv $PG_BU $MONGO_BU $KEY_BU $VAULT_BU circleci_export
-    rm -f circleci_export.tar.gz
-    tar cfz circleci_export.tar.gz circleci_export
-
-    rm -rf circleci_export
 }

--- a/migrate/3.0-preflight.sh
+++ b/migrate/3.0-preflight.sh
@@ -21,15 +21,15 @@ function preflight_checks() {
     then
         echo "Namespace '$NAMESPACE' not found."
         exit 1
-    elif [[ ! -z "$SKIP_POSTGRES" && ! -s $PG_BU/circle.sql ]]
+    elif [[ -z "$SKIP_POSTGRES" && ! -s $PG_BU/circle.sql ]]
     then
         echo "Postgres data at '$PG_BU/circle.sql' not found (or is empty)"
         exit 1
-    elif [[ ! -z "$SKIP_MONGO" && ! -s $MONGO_BU/circle_ghe/organizations.bson ]]
+    elif [[ -z "$SKIP_MONGO" && ! -s $MONGO_BU/circle_ghe/organizations.bson ]]
     then
         echo "Mongo data at '$MONGO_BU' not found (or is empty)"
         exit 1
-    elif [[ ! -z "$SKIP_VAULT" && $(du -s $VAULT_BU 2>/dev/null | awk '{print $1}') -lt 5 ]]
+    elif [[ -z "$SKIP_VAULT" && $(du -s $VAULT_BU 2>/dev/null | awk '{print $1}') -lt 5 ]]
     then
         echo "Vault data at '$VAULT_BU' not found (or is empty)"
         exit 1

--- a/migrate/3.0-preflight.sh
+++ b/migrate/3.0-preflight.sh
@@ -21,15 +21,15 @@ function preflight_checks() {
     then
         echo "Namespace '$NAMESPACE' not found."
         exit 1
-    elif [[ ! "$SKIP_DATABASE_IMPORT" = "true" && ! -s $PG_BU/circle.sql ]]
+    elif [[ ! -z "$SKIP_POSTGRES" && ! -s $PG_BU/circle.sql ]]
     then
         echo "Postgres data at '$PG_BU/circle.sql' not found (or is empty)"
         exit 1
-    elif [[ ! "$SKIP_DATABASE_IMPORT" = "true" && ! -s $MONGO_BU/circle_ghe/organizations.bson ]]
+    elif [[ ! -z "$SKIP_MONGO" && ! -s $MONGO_BU/circle_ghe/organizations.bson ]]
     then
         echo "Mongo data at '$MONGO_BU' not found (or is empty)"
         exit 1
-    elif [[ $(du -s $VAULT_BU 2>/dev/null | awk '{print $1}') -lt 5 ]]
+    elif [[ ! -z "$SKIP_VAULT" && $(du -s $VAULT_BU 2>/dev/null | awk '{print $1}') -lt 5 ]]
     then
         echo "Vault data at '$VAULT_BU' not found (or is empty)"
         exit 1

--- a/migrate/3.0-restore.sh
+++ b/migrate/3.0-restore.sh
@@ -3,7 +3,7 @@
 ##
 # CircleCI Database Import Script
 #
-#   * Intended only for use with installations of CircleCI Server 3.0.
+#   * Intended only for use with installations of CircleCI Server 3.x.
 #
 #   This script will import data from a CircleCI Server 2.19.x instance
 #   given the tarball called `circleci_export.tar.gz` has already been
@@ -108,6 +108,8 @@ function circleci_database_import() {
     then
         MONGO_BU="${BACKUP_DIR}/circleci-mongo-export"
         import_mongo
+
+        reinject_bottoken
     fi
     
     if [ ! "$SKIP_POSTGRES" = "true" ];
@@ -124,8 +126,6 @@ function circleci_database_import() {
 
     if [ ! "$SKIP_MONGO $SKIP_POSTGRES $SKIP_VAULT" = "true true true" ];
     then
-        reinject_bottoken
-
         echo "...scaling application deployments to 1..."
         scale_deployments 1
     fi

--- a/migrate/3.0-restore.sh
+++ b/migrate/3.0-restore.sh
@@ -131,6 +131,8 @@ function circleci_database_import() {
     fi
 
     echo "CircleCI Server Import Complete"
+
+    scale_reminder
     key_reminder
 }
 

--- a/migrate/3.0-scale.sh
+++ b/migrate/3.0-scale.sh
@@ -13,3 +13,9 @@ scale_deployments() {
         exit 1
     fi
 }
+
+scale_reminder() {
+    echo "Please note all deployments have been scaled to 1."
+    echo "This is not necessarily desirable in all scenarios."
+    echo "Consider scaling some deployments for high availability ."
+}

--- a/migrate/README.md
+++ b/migrate/README.md
@@ -1,3 +1,3 @@
-`migrate/migrate.sh` will copy data from a 2.19 instance into a 3.0 instance.
+`migrate/migrate.sh` will copy data from a 2.19.x instance into a 3.x instance.
 
 Please see [Server 3 Migration Instructions](https://circleci.com/docs/2.0/server-3-install-migration/) for instructions.

--- a/migrate/migrate.sh
+++ b/migrate/migrate.sh
@@ -4,11 +4,11 @@
 # CircleCI Server Migration Script
 #
 #   This script is for installations migrating from the latest CircleCI Server 2.19.x
-#   to CircleCI Server 3.0.
+#   to CircleCI Server 3.x.
 #
 #   This script will create a tar ball of CircleCI encryption & signing keys,
 #   Vault, PostgreSQL and Mongo databases. The tar ball will be copied locally,
-#   extracted, and passed through kubectl commands to the 3.0 installation.
+#   extracted, and passed through kubectl commands to the 3.x installation.
 ##
 
 DIR=$(dirname $0)
@@ -127,7 +127,7 @@ HOST="${USERNAME}@${HOSTNAME}"
 
 if [ -z $NAMESPACE ];
 then
-    echo "Now we need the namespace that has CircleCI Server 3.0 installed."
+    echo "Now we need the namespace that has CircleCI Server 3.x installed."
     read -p 'Namespace: ' NAMESPACE
 fi
 

--- a/migrate/migrate.sh
+++ b/migrate/migrate.sh
@@ -12,14 +12,20 @@
 ##
 
 DIR=$(dirname $0)
-SKIP_DATABASE_IMPORT=""
 ARGS="${@:1}"
 
 # Init
 
 help_init_options() {
     # Help message for Init menu
-    echo "  -s|--skip-databases           Skip importing Postgres and Mongodb data locally"
+    echo "  -s|--skip-databases           Skip migrating Postgres and Mongodb data"
+    echo "  -p|--skip-postgres            Skip migrating Postgres data"
+    echo "  -m|--skip-mongo               Skip migrating Mongodb data"
+    echo "  -v|--skip-vault               Skip migrating Vault data"
+    echo "     --hostname                 Hostname of the 2.x installation"
+    echo "     --key                      Path to 2.x SSH key file"
+    echo "     --user                     Username for 2.x SSH access"
+    echo "     --namespace                Namespace of the 3.x install"
     echo "  -h|--help                     Print help text"
 }
 
@@ -31,7 +37,40 @@ init_options() {
     key="${1}"
     case $key in
         -s|--skip-databases)
-            SKIP_DATABASE_IMPORT="--skip-databases"
+            SKIP_POSTGRES="--skip-postgres"
+            SKIP_MONGO="--skip-mongo"
+            shift # past argument
+        ;;
+        -p|--skip-postgres)
+            SKIP_POSTGRES="--skip-postgres"
+            shift # past argument
+        ;;
+        -m|--skip-mongo)
+            SKIP_MONGO="--skip-mongo"
+            shift # past argument
+        ;;
+        -v|--skip-vault)
+            SKIP_VAULT="--skip-vault"
+            shift # past argument
+        ;;
+        --hostname)
+            shift # need the next arg
+            HOSTNAME=$1
+            shift # past argument
+        ;;
+        --key)
+            shift # need the next arg
+            KEY_FILE=$1
+            shift # past argument
+        ;;
+        --user)
+            shift # need the next arg
+            USERNAME=$1
+            shift # past argument
+        ;;
+        --namespace)
+            shift # need the next arg
+            NAMESPACE=$1
             shift # past argument
         ;;
         -h|--help)
@@ -50,9 +89,12 @@ init_options() {
         help_init_options
         exit 1
     fi
+
+    SKIP="${SKIP_POSTGRES} ${SKIP_MONGO} ${SKIP_VAULT}"
 }
 
 init_options $ARGS
+
 
 echo "Note: this script assumes passwordless sudo access on the services box."
 echo "Additionally, the 2.19.x application will be stopped and not started back up."
@@ -60,15 +102,34 @@ echo "Additionally, the 2.19.x application will be stopped and not started back 
 echo ""
 echo ""
 
-echo "We need some information before we can begin."
-echo "First, let's start with your 2.19.x installation."
-read -p 'Hostname: ' HOSTNAME
-read -p 'SSH Key File: ' KEY_FILE
-read -p 'SSH Username: ' USERNAME
+if [[ -z $HOSTNAME || -z $KEY_FILE || -z $USERNAME ]];
+then
+    echo "We need some information before we can begin."
+    echo "First, let's start with your 2.19.x installation."
+fi
+
+if [ -z $HOSTNAME ];
+then
+    read -p 'Hostname: ' HOSTNAME
+fi
+
+if [ -z $KEY_FILE ];
+then
+    read -p 'SSH Key File: ' KEY_FILE
+fi
+
+if [ -z $USERNAME ];
+then
+    read -p 'SSH Username: ' USERNAME
+fi
+
 HOST="${USERNAME}@${HOSTNAME}"
 
-echo "Now we need the namespace that has CircleCI Server 3.0 installed."
-read -p 'Namespace: ' NAMESPACE
+if [ -z $NAMESPACE ];
+then
+    echo "Now we need the namespace that has CircleCI Server 3.0 installed."
+    read -p 'Namespace: ' NAMESPACE
+fi
 
 echo ""
 echo "."
@@ -79,17 +140,20 @@ echo ""
 
 echo "## CircleCI Server Migration ##"
 
-echo "...stopping the application"
-ssh -i $KEY_FILE -t $HOST -- "replicatedctl app stop"
-
-echo "...copying export script remotely"
+echo "...copying export scripts remotely"
 scp -i $KEY_FILE ${DIR}/2.19-*.sh ${HOST}:
 
-echo "...sleeping while the application stops"
-sleep 60
+if [ ! "$SKIP" = "--skip-postgres --skip-mongo --skip-vault" ];
+then
+    echo "...stopping the application"
+    ssh -i $KEY_FILE -t $HOST -- "replicatedctl app stop"
+    
+    echo "...sleeping while the application stops"
+    sleep 60
+fi
 
-#echo "...initiating export"
-ssh -i $KEY_FILE -t $HOST -- "sudo bash 2.19-export.sh ${SKIP_DATABASE_IMPORT}"
+echo "...initiating export"
+ssh -i $KEY_FILE -t $HOST -- "sudo bash 2.19-export.sh ${SKIP}"
 
 echo "...copying export locally"
 scp -i $KEY_FILE ${HOST}:circleci_export.tar.gz .
@@ -97,4 +161,4 @@ scp -i $KEY_FILE ${HOST}:circleci_export.tar.gz .
 echo "...extracting export"
 tar zxvf circleci_export.tar.gz
 
-bash ${DIR}/3.0-restore.sh $SKIP_DATABASE_IMPORT $NAMESPACE
+bash ${DIR}/3.0-restore.sh $SKIP $NAMESPACE

--- a/migrate/migrate.sh
+++ b/migrate/migrate.sh
@@ -22,7 +22,7 @@ help_init_options() {
     echo "  -p|--skip-postgres            Skip migrating Postgres data"
     echo "  -m|--skip-mongo               Skip migrating Mongodb data"
     echo "  -v|--skip-vault               Skip migrating Vault data"
-    echo "     --hostname                 Hostname of the 2.x installation"
+    echo "     --host                     Hostname of the 2.x installation"
     echo "     --key                      Path to 2.x SSH key file"
     echo "     --user                     Username for 2.x SSH access"
     echo "     --namespace                Namespace of the 3.x install"
@@ -53,9 +53,9 @@ init_options() {
             SKIP_VAULT="--skip-vault"
             shift # past argument
         ;;
-        --hostname)
+        --host)
             shift # need the next arg
-            HOSTNAME=$1
+            HOST=$1
             shift # past argument
         ;;
         --key)
@@ -102,15 +102,15 @@ echo "Additionally, the 2.19.x application will be stopped and not started back 
 echo ""
 echo ""
 
-if [[ -z $HOSTNAME || -z $KEY_FILE || -z $USERNAME ]];
+if [[ -z $HOST || -z $KEY_FILE || -z $USERNAME ]];
 then
     echo "We need some information before we can begin."
     echo "First, let's start with your 2.19.x installation."
 fi
 
-if [ -z $HOSTNAME ];
+if [ -z $HOST ];
 then
-    read -p 'Hostname: ' HOSTNAME
+    read -p 'Hostname: ' HOST
 fi
 
 if [ -z $KEY_FILE ];
@@ -123,7 +123,7 @@ then
     read -p 'SSH Username: ' USERNAME
 fi
 
-HOST="${USERNAME}@${HOSTNAME}"
+HOST="${USERNAME}@${HOST}"
 
 if [ -z $NAMESPACE ];
 then


### PR DESCRIPTION
SERVER-1288

Some customers may only have Postgres externalized
and need help migrating. DCEs would have to do the
process manually without this script.