### PR TITLE
[server-1349] restarting postgres during restore process

### DIFF
--- a/migrate/3.0-restore.sh
+++ b/migrate/3.0-restore.sh
@@ -111,8 +111,11 @@ function circleci_database_import() {
         echo "...scaling application deployments to 0..."
         scale_deployments 0
 
-        # delete postgres to clear any remaining connections
-        kubectl delete pod -l app.kubernetes.io/name=postgresql -n "$NAMESPACE"
+        # if postgres is internal, delete pod to clear any remaining connections
+        if [ ! "$SKIP_POSTGRES" = "true" ];
+        then
+            kubectl delete pod -l app.kubernetes.io/name=postgresql -n "$NAMESPACE"
+        fi
         
         # wait one minute for pods to scale down
         sleep 60

--- a/migrate/3.0-restore.sh
+++ b/migrate/3.0-restore.sh
@@ -110,6 +110,9 @@ function circleci_database_import() {
     then
         echo "...scaling application deployments to 0..."
         scale_deployments 0
+
+        # delete postgres to clear any remaining connections
+        kubectl delete pod -l app.kubernetes.io/name=postgresql -n "$NAMESPACE"
         
         # wait one minute for pods to scale down
         sleep 60

--- a/migrate/migrate.sh
+++ b/migrate/migrate.sh
@@ -89,7 +89,6 @@ init_options() {
 
     if [ ${#POSITIONAL[@]} -gt 0 ]
     then
-        echo "${POSITIONAL[@]}"
         help_init_options
         exit 1
     fi

--- a/migrate/migrate.sh
+++ b/migrate/migrate.sh
@@ -89,7 +89,7 @@ init_options() {
 
     if [ ${#POSITIONAL[@]} -gt 0 ]
     then
-        echo ${POSITIONAL[@]}
+        echo "${POSITIONAL[@]}"
         help_init_options
         exit 1
     fi


### PR DESCRIPTION
Open connections to postgres are causing duplicate records in the `build_queue_migrations` table on the `circle` database in postgres. We restart postgres during the restore process to kill any open connections

https://circleci.atlassian.net/browse/SERVER-1349