### PR TITLE
Add jq check to migrate.sh as a pre flight check.

### DIFF
--- a/migrate/migrate.sh
+++ b/migrate/migrate.sh
@@ -99,6 +99,11 @@ init_options() {
 # shellcheck disable=SC2086
 init_options $ARGS
 
+if [ ! "$(which jq)" ]
+then
+    echo ... "'jq' not found. Please install jq locally in order to run this script."
+    exit 1
+fi
 
 echo "Note: this script assumes passwordless sudo access on the services box."
 echo "Additionally, the 2.19.x application will be stopped and not started back up."


### PR DESCRIPTION
migrate.sh bombs out late in the process if run as non-root on a base Ubuntu Focal instance because jq is not installed. Rather than wait 30 minutes or more for the script to shutdown 2.19 and export all the data before failing, check that jq is installed before doing anything.