### PR TITLE
[SERVER-2003] Add Helm labels and annotations to flyway migration job

### DIFF
--- a/kots-exporter/kots-exporter.sh
+++ b/kots-exporter/kots-exporter.sh
@@ -299,7 +299,8 @@ execute_flyway_migration(){
 
     echo "Fetching values from $FRONTEND_POD pod"
     # shellcheck disable=SC2046
-    export $(kubectl -n "$namespace" exec "$FRONTEND_POD" -c frontend -- printenv | grep -Ew 'POSTGRES_USERNAME|POSTGRES_PORT|POSTGRES_PASSWORD|POSTGRES_HOST' | xargs )
+    export $(kubectl -n "$namespace" exec "$FRONTEND_POD" -c frontend -- printenv | grep -Ew 'POSTGRES_USERNAME|POSTGRES_PORT|POSTGRES_PASSWORD|POSTGRES_HOST|K8S_POD_NAMESPACE' | xargs )
+    export RELEASE_NAME=$slug
 
     echo "Creating job/circle-migrator -"
     ( envsubst < "$path"/templates/circle-migrator.yaml | kubectl -n "$namespace" apply -f - ) \

--- a/kots-exporter/templates/circle-migrator.yaml
+++ b/kots-exporter/templates/circle-migrator.yaml
@@ -2,9 +2,14 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: circle-migrator
+  annotations:
+    meta.helm.sh/release-name: $RELEASE_NAME
+    meta.helm.sh/release-namespace: $K8S_POD_NAMESPACE
   labels:
     app: circle-migrator
     layer: application
+    app.kubernetes.io/managed-by: Helm
+
 spec:
   template:
     metadata:


### PR DESCRIPTION
:gear: **Issue**

- [SERVER-2003](https://circleci.atlassian.net/browse/SERVER-2003)

:white_check_mark: **Fix**

One way for us to cleanup the migration job resource is to have Helm remove it automatically on next `helm upgrade`. In order for this to happen we can simply add the necessary helm annotations and labels to the job metadata. During the next Helm upgrade the job will be removed as it's not part of the release. 

- We can obtain the namespace directly from the `K8S_POD_NAMESPACE` environment variable in the Frontend pod (we are already using it to obtain Postgres info)

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [ ] Tested Updating Existing Instance
- [ ] Installed on new instance
