### PR TITLE
[SERVER-2003] Remove migration job once it has completed

### DIFF
--- a/kots-exporter/kots-exporter.sh
+++ b/kots-exporter/kots-exporter.sh
@@ -306,9 +306,13 @@ execute_flyway_migration(){
     || error_exit "Job circle-migrator creation error"
 
     echo "Waiting job/circle-migrator to complete -"
-    (kubectl wait job/circle-migrator --namespace "$namespace" --for condition="complete" --timeout=300s \
-    && echo "++++ DB Migration job is successful." ) \
-    || error_exit "Status wait timeout for job/circle-migrator, Check the Log via - kubectl logs pods -l app=circle-migrator"
+    if (kubectl wait job/circle-migrator --namespace "$namespace" --for condition="complete" --timeout=60s); then
+        echo "++++ DB Migration job is successful."
+        echo "Removing job/circle-migrator -"
+        kubectl delete job/circle-migrator --namespace "$namespace"
+    else
+        error_exit "Status wait timeout for job/circle-migrator, Check the Log via - kubectl logs pods -l app=circle-migrator"
+    fi
 }
 
 rm_kots_annot_label_resources(){

--- a/kots-exporter/kots-exporter.sh
+++ b/kots-exporter/kots-exporter.sh
@@ -306,7 +306,7 @@ execute_flyway_migration(){
     || error_exit "Job circle-migrator creation error"
 
     echo "Waiting job/circle-migrator to complete -"
-    if (kubectl wait job/circle-migrator --namespace "$namespace" --for condition="complete" --timeout=60s); then
+    if (kubectl wait job/circle-migrator --namespace "$namespace" --for condition="complete" --timeout=300s); then
         echo "++++ DB Migration job is successful."
         echo "Removing job/circle-migrator -"
         kubectl delete job/circle-migrator --namespace "$namespace"

--- a/kots-exporter/kots-exporter.sh
+++ b/kots-exporter/kots-exporter.sh
@@ -72,7 +72,7 @@ check_prereq(){
 
 check_required_args(){
     echo ""
-    echo "############ CHECKING RQUIRED ARGUEMENTS ################"
+    echo "############ CHECKING REQUIRED ARGUMENTS ################"
 
     # check for required arguments
     if [[ -z $slug || -z $namespace ]];
@@ -338,7 +338,7 @@ rm_kots_annot_label_resources(){
 
     echo "Deleting job inject-bottoken-xxxx"
     kubectl -n $namespace delete "$(kubectl -n $namespace get jobs -o name | grep inject)" \
-    || echo "Manully run the command: kubectl -n $namespace delete $(kubectl -n $namespace get jobs -o name | grep inject)"
+    || echo "Manually run the command: kubectl -n $namespace delete $(kubectl -n $namespace get jobs -o name | grep inject)"
 }
 
 output_message(){
@@ -351,8 +351,8 @@ output_message(){
     echo ""
     echo "-------------------------------------------------------------------------"
     
-    echo "## Progres Chart Upgrade Preparation"
-    echo "Upgrading to server CircleCI Server 4.0 includes upgrading the Posgres chart"
+    echo "## Postgres Chart Upgrade Preparation"
+    echo "Upgrading to server CircleCI Server 4.0 includes upgrading the Postgres chart"
     echo "Before upgrading, we need to prepare your postgres instance."
     echo "This is only needed if your Postgres Instance is not externalized."
     echo ""

--- a/kots-exporter/templates/circle-migrator.yaml
+++ b/kots-exporter/templates/circle-migrator.yaml
@@ -36,4 +36,4 @@ spec:
           requests:
             cpu: 2m
             memory: 10Mi
-      restartPolicy: OnFailure
+      restartPolicy: Never


### PR DESCRIPTION
:gear: **Issue**

- [SERVER-2003](https://circleci.atlassian.net/browse/SERVER-2003)

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->

We can safely remove the migration job once the `kubectl wait` command completes successfully.

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [x] Tested Updating Existing Instance
- [ ] Installed on new instance

Test a successful (no-op) migration:

```
./kots-exporter.sh -a circleci-server -n circleci -f flyway                                                                                                                                                                                            ...
############ RUNNING FLYWAY DB MIGRATION JOB ################
Checking if job/circle-migrator already ran -
Fetching values from pod/frontend-6758678865-zlfm5 pod
Creating job/circle-migrator -
job.batch/circle-migrator created
Waiting job/circle-migrator to complete -
job.batch/circle-migrator condition met
++++ DB Migration job is successful.
Removing job/circle-migrator -
job.batch "circle-migrator" deleted
```

Test a failure (wrong Postgres password supplied):

```
...
############ RUNNING FLYWAY DB MIGRATION JOB ################
Checking if job/circle-migrator already ran -
Fetching values from pod/frontend-6758678865-zlfm5 pod
Creating job/circle-migrator -
job.batch/circle-migrator created
Waiting job/circle-migrator to complete -
error: timed out waiting for the condition on jobs/circle-migrator
------->> Error: Status wait timeout for job/circle-migrator, Check the Log via - kubectl logs pods -l app=circle-migrator
[1]    72896 terminated  ./kots-exporter.sh -a circleci-server -n circleci -f flyway
```