### PR TITLE
server-2020/decrypt-telegraf-config

### DIFF
--- a/kots-exporter/kots-exporter.sh
+++ b/kots-exporter/kots-exporter.sh
@@ -197,6 +197,10 @@ modify_helm_values(){
     yq -i '.global.container.org = ""' "$path"/output/helm-values.yaml || error_exit "Org addition has failed."
 
     echo ""
+    echo "Decoding Telegraf Config"
+    DATA=$( yq '.telegraf.config.custom_config_file' $path/output/helm-values.yaml | base64 -d) yq -i '.telegraf.config.custom_config_file = strenv(DATA)' $path/output/helm-values.yaml || error_exit "Decoding Telegraf config has failed."
+
+    echo ""
     echo "Altering Postgres block for new chart"
     if [[ $(yq '.postgresql.internal' "$path"/output/helm-values.yaml) == true ]]
     then


### PR DESCRIPTION
:gear: **Issue**

<!-- What's wrong; why the change? A good place to reference the ticket if it exists. -->
The migration script outputs telegraf's config in base64
We should decode this so that a customer can easily update it

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->
Telegraf config is now decoded in values.yaml

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [ ] Tested Updating Existing Instance
- [ ] Installed on new instance
