### PR TITLE
Server 2096 chart version

### DIFF
--- a/support/README.md
+++ b/support/README.md
@@ -24,7 +24,7 @@ When ready, run the support bundle from the current directory and wait for it to
 
 ```bash
 # Within the server/support directory
-kubectl support-bundle support-bundle.yaml
+kubectl support-bundle --namespace=<namespace> support-bundle.yaml
 ```
 
 A sanitized .tar.gz file will be created in the current directory - this can be sent to the support team for further debugging.

--- a/support/support-bundle.yaml
+++ b/support/support-bundle.yaml
@@ -61,6 +61,11 @@ spec:
       command: ["/bin/sh"]
       args: ["-c","df -h /bitnami/rabbitmq/mnesia"]
       timeout: 10s
+  hostCollectors:
+  - run:
+      collectorName: "helm-list"
+      command: "/bin/sh"
+      args: ["-c", "helm list --all-namespaces" ]
   redactors:
   - name: Redact Object storage credentials
     fileSelector:


### PR DESCRIPTION
:gear: **Issue**

We don't know what server version the customer is using

:white_check_mark: **Fix**

Let's pull the chart version via helm list so we know what version the customer is on.

also, I am proposing we do not filter the output to just circleci for 2 reasons:

- It can be useful to know what their backup situation is, so getting the velero chart output if present will be nice
- we have had customers support tickets because a customer was running 2 instances of circleci beside each other, this would also be nice to know if there are other circleci applications install on the cluster.


:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [ ] Tested Updating Existing Instance
- [ ] Installed on new instance
