### PR TITLE
[SERVER-2273] Migrate 3.4 to a new 4.0 instance 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@circleci-public/scale

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# CircleCI Scripts & Tools
+
+This repository contains various tools and scripts which supports CircleCI server installation and migrations.
+
+### [kots-exporter](./kots-exporter)
+
+`kots-exporter` script downloads the KOTS config from CircleCI `server 3.x` and create a helm value file which can be used in CircleCI `server 4.0` installation.
+
+### [migrate](./migrate)
+
+`migrate` directory holds collection of scripts which is resposible for backing-up the data from CircleCI `server 2.x` which can be restored into CircleCI `server 3.x` or `server 4.x` instance.
+
+### [passwords](./passwords)
+
+`passwords` directory contains [generate_password.sh](./passwords/generate_password.sh) script which generates various password or secrets for CircleCI `server 4.x` helm value file.
+
+### [support](./support/)
+
+`support` directory contains support-bundle template and instruction to generate support-bundle.

--- a/migrate-3-to-4/README.md
+++ b/migrate-3-to-4/README.md
@@ -1,0 +1,20 @@
+# Migrating 3 to 4
+**Stop!** You probably want [kots-exporter](../kots-exporter/).  This script should only be used at the recomendation of your CircleCI Contact.
+
+## Prequsites
+1. There exists a 4.0 instance where reality check has successfully run.
+
+2. In the 3.4 environment, add the same [docker-registry secret](https://circleci.com/docs/server/installation/phase-2-core-services/#pull-images) that is used in the 4.0 environment
+
+## Using
+`./exporter.sh` will export all the datastores from a 3.4 instance onto your local machine.  `./restore.sh` will import the data now on your local machine into the 4.0 environment
+
+### Export data from 3.4
+1.  Set the kubectl context to the CircleCI 3.4 instance you are migrating **From**
+2.  Run: `./exporter.sh -n <namespace>`
+
+### Import data into 4.0
+1.  Set the Kubectl context to the CirlceCI 4.0 instance you are migrating **To**
+2.  Run: `./restore.sh <namespace>`
+3.  Update CircleCI 4.0 to point at the storage bucket from 3.4
+4.  Update Signing and Encryption keys they will be in `circleci_export/encryptkey` and `circleci_export/signkey`

--- a/migrate-3-to-4/README.md
+++ b/migrate-3-to-4/README.md
@@ -1,5 +1,5 @@
 # Migrating 3 to 4
-**Stop!** You probably want [kots-exporter](../kots-exporter/).  This script should only be used at the recomendation of your CircleCI Contact.
+**Stop!** You probably want [kots-exporter](../kots-exporter/).  This script should only be used at the recommendation of your CircleCI Contact.
 
 ## Prequsites
 1. There exists a 4.0 instance where reality check has successfully run.

--- a/migrate-3-to-4/bottoken.sh
+++ b/migrate-3-to-4/bottoken.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function reinject_bottoken() {
+    JOB_NAME=$(kubectl -n "$NAMESPACE" get jobs -o json | jq '.items[0].metadata.name' -r)
+    echo "Found job $JOB_NAME"
+    kubectl get job "${JOB_NAME}" -o json | jq 'del(.spec.template.metadata.labels."controller-uid") | del(.spec.selector)' > bottokenjob.json
+    kubectl replace --force -f bottokenjob.json
+}

--- a/migrate-3-to-4/exporter.sh
+++ b/migrate-3-to-4/exporter.sh
@@ -2,7 +2,6 @@
 set -e
 
 logFile="kots-exporter-script-$(date +%Y-%h-%d-%H%M%S).log"
-kotsCleanupLogFile="kots-cleanup-$(date +%Y-%h-%d-%H%M%S).log"
 
 help_init_options() {
     echo ""
@@ -13,7 +12,6 @@ help_init_options() {
     echo "Arguments:"
     echo "  -n|--namespace          (Required) k8s namespace where kots admin is installed"
     echo "                           Defaults to 'circleci-server'"
-    echo "  -l|--license            (Required) License Key String"
     echo "  -h|--help                Print help text"
 
     echo ""
@@ -21,14 +19,6 @@ help_init_options() {
     echo "# Run kots-exporter with namespace"
     echo "./exporter.sh -n <k8s-namespace>"
     echo ""
-    echo "# Run execute_flyway_migration (database migration)"
-    echo "./kots-exporter.sh -n <k8s-namespace> -f flyway"
-    echo ""
-    echo "# Run kots annotation/label cleanup function only"
-    echo "./kots-exporter.sh -n <k8s-namespace> -f cleanup_kots"
-    echo ""
-    echo "# To display output message again"
-    echo "./kots-exporter.sh -n <k8s-namespace> -f message"
 }
 
 check_prereq(){

--- a/migrate-3-to-4/exporter.sh
+++ b/migrate-3-to-4/exporter.sh
@@ -106,9 +106,10 @@ execute_flyway_migration(){
 }
 
 export_postgres() {
+    echo "Exporting PostgreSQL data"
     PG_POD=$(kubectl -n "$NAMESPACE" get pods | grep postgresql | tail -1 | awk '{print $1}')
     PG_PASSWORD=$(kubectl -n "$NAMESPACE" get secrets postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)
-    kubectl -n "$namepsace" exec -it "$PG_POD" -- bash -c "export PGPASSWORD='$PG_PASSWORD' && pg_dumpall -U postgres -c" > circle.sql
+    kubectl -n "$NAMESPACE" exec -it "$PG_POD" -- bash -c "export PGPASSWORD='$PG_PASSWORD' && pg_dumpall -U postgres -c" > circle.sql
 }
 
 ##
@@ -139,6 +140,7 @@ check_postgres() {
 }
 
 export_mongo() {
+    echo "Exporting MongoDB data"
     MONGO_POD="mongodb-0"
     MONGODB_USERNAME="root"
     MONGODB_PASSWORD=$(kubectl -n "$namespace" get secrets mongodb -o jsonpath="{.data.mongodb-root-password}" | base64 --decode)
@@ -203,4 +205,5 @@ execute_flyway_migration
 export_postgres
 check_postgres
 export_mongo
+export_vault
 output_message

--- a/migrate-3-to-4/exporter.sh
+++ b/migrate-3-to-4/exporter.sh
@@ -148,6 +148,17 @@ export_vault() {
     rm -rf ${BACKUP_DIR}/file
 }
 
+export_keys() {
+    echo "Exporting Keyset Keys"
+
+    SIGN_KEY=$(kubectl get deployment frontend -o json | jq '.spec.template.spec.containers[0].env | map(select(.name == "CIRCLE_SECRETS__KEYSET__SIGN"))[0].value')
+    echo $SIGN_KEY >> ${BACKUP_DIR}/signkey
+    ENCRYPTION_KEY=$(kubectl get deployment frontend -o json | jq '.spec.template.spec.containers[0].env | map(select(.name == "CIRCLE_SECRETS__KEYSET__CRYPT"))[0].value')
+    echo $ENCRYPTION_KEY >> ${BACKUP_DIR}/encryptkey
+
+
+}
+
 output_message(){
     echo ""
     echo "NOTE: After server 3.x to 4.x migration, You must rerun the Nomad terraform with modified value of 'server_endpoint' variable"
@@ -191,9 +202,10 @@ done
 
 check_prereq
 create_folders
-# execute_flyway_migration
+execute_flyway_migration
 export_postgres
 check_postgres
 export_mongo
 export_vault
+export_keys
 output_message

--- a/migrate-3-to-4/exporter.sh
+++ b/migrate-3-to-4/exporter.sh
@@ -152,9 +152,9 @@ export_keys() {
     echo "Exporting Keyset Keys"
 
     SIGN_KEY=$(kubectl get deployment frontend -o json | jq '.spec.template.spec.containers[0].env | map(select(.name == "CIRCLE_SECRETS__KEYSET__SIGN"))[0].value')
-    echo $SIGN_KEY >> ${BACKUP_DIR}/signkey
+    echo "$SIGN_KEY" >> ${BACKUP_DIR}/signkey
     ENCRYPTION_KEY=$(kubectl get deployment frontend -o json | jq '.spec.template.spec.containers[0].env | map(select(.name == "CIRCLE_SECRETS__KEYSET__CRYPT"))[0].value')
-    echo $ENCRYPTION_KEY >> ${BACKUP_DIR}/encryptkey
+    echo "$ENCRYPTION_KEY" >> ${BACKUP_DIR}/encryptkey
 
 
 }

--- a/migrate-3-to-4/exporter.sh
+++ b/migrate-3-to-4/exporter.sh
@@ -64,11 +64,9 @@ execute_flyway_migration(){
     echo "############ RUNNING FLYWAY DB MIGRATION JOB ################"
 
     echo "Checking if job/circle-migrator already ran -"
-    if kubectl get job/circle-migrator -n $namespace -o name > /dev/null 2>&1
+    if kubectl get job/circle-migrator -n "$namespace" -o name > /dev/null 2>&1
     then
-        echo "Job circle-migrator has already been run, If you want to run again, delete the job circle-migrator via below command"
-        echo "kubectl delete job/circle-migrator -n $namespace"
-        echo "To Rerun: ./kots-exporter.sh -a $slug -n $namespace -f flyway"
+        echo "Job circle-migrator has already been run"
         error_exit
     fi
 
@@ -87,7 +85,7 @@ execute_flyway_migration(){
     if (kubectl wait job/circle-migrator --namespace "$namespace" --for condition="complete" --timeout=600s); then
         echo "++++ DB Migration job is successful."
         echo "Fetching pod logs -"
-        kubectl  -n "$namespace" logs "$(kubectl -n $namespace get pods -l app=circle-migrator -o name)" > "$path"/logs/circle-migrator.log
+        kubectl  -n "$namespace" logs "$(kubectl -n "$namespace" get pods -l app=circle-migrator -o name)" > "$path"/logs/circle-migrator.log
         echo "Pod log is available at $path/logs/circle-migrator.log"
         echo "Removing job/circle-migrator -"
         kubectl delete job/circle-migrator --namespace "$namespace"

--- a/migrate-3-to-4/exporter.sh
+++ b/migrate-3-to-4/exporter.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+set -e
+
+logFile="kots-exporter-script-$(date +%Y-%h-%d-%H%M%S).log"
+kotsCleanupLogFile="kots-cleanup-$(date +%Y-%h-%d-%H%M%S).log"
+
+help_init_options() {
+    echo ""
+    # Help message for Init menu
+    echo "Usage:"
+    echo "    ./exporter.sh [arguments]"
+    echo ""
+    echo "Arguments:"
+    echo "  -n|--namespace          (Required) k8s namespace where kots admin is installed"
+    echo "                           Defaults to 'circleci-server'"
+    echo "  -l|--license            (Required) License Key String"
+    echo "  -h|--help                Print help text"
+
+    echo ""
+    echo "Example :-"
+    echo "# Run kots-exporter with namespace"
+    echo "./exporter.sh -n <k8s-namespace>"
+    echo ""
+    echo "# Run execute_flyway_migration (database migration)"
+    echo "./kots-exporter.sh -n <k8s-namespace> -f flyway"
+    echo ""
+    echo "# Run kots annotation/label cleanup function only"
+    echo "./kots-exporter.sh -n <k8s-namespace> -f cleanup_kots"
+    echo ""
+    echo "# To display output message again"
+    echo "./kots-exporter.sh -n <k8s-namespace> -f message"
+}
+
+check_prereq(){
+    echo ""
+    # check if kubectl is installed
+    if ! command -v kubectl version &> /dev/null
+    then
+        error_exit "kubectl could not be found."
+    fi
+
+    # check helm is installed
+    if ! command -v helm version &> /dev/null
+    then
+        error_exit "helm could not be found."
+    fi
+
+    # check yq is installed
+    if ! command -v yq -V &> /dev/null
+    then
+        error_exit "yq could not be found."
+    fi
+
+    # check jq is installed
+    if ! command -v jq -V &> /dev/null
+    then
+        error_exit "jq could not be found."
+    fi
+}
+
+create_folders(){
+    echo ""
+    echo "############ CREATING FOLDERS ################"
+
+    # Creating
+    rm -rf  "$path/output" 2> /dev/null
+    mkdir -p "$path/output" && echo "output folder has been created."
+}
+
+execute_flyway_migration(){
+    echo ""
+    echo "############ RUNNING FLYWAY DB MIGRATION JOB ################"
+
+    echo "Checking if job/circle-migrator already ran -"
+    if kubectl get job/circle-migrator -n $namespace -o name > /dev/null 2>&1
+    then
+        echo "Job circle-migrator has already been run, If you want to run again, delete the job circle-migrator via below command"
+        echo "kubectl delete job/circle-migrator -n $namespace"
+        echo "To Rerun: ./kots-exporter.sh -a $slug -n $namespace -f flyway"
+        error_exit
+    fi
+
+    FRONTEND_POD=$(kubectl -n "$namespace" get pod -l app=frontend -o name | tail -1)
+    export FRONTEND_POD
+
+    echo "Fetching values from $FRONTEND_POD pod"
+    # shellcheck disable=SC2046
+    export $(kubectl -n "$namespace" exec "$FRONTEND_POD" -c frontend -- printenv | grep -Ew 'POSTGRES_USERNAME|POSTGRES_PORT|POSTGRES_PASSWORD|POSTGRES_HOST' | xargs )
+
+    echo "Creating job/circle-migrator -"
+    ( envsubst < "$path"/templates/circle-migrator.yaml | kubectl -n "$namespace" apply -f - ) \
+    || error_exit "Job circle-migrator creation error"
+
+    echo "Waiting job/circle-migrator to complete -"
+    if (kubectl wait job/circle-migrator --namespace "$namespace" --for condition="complete" --timeout=600s); then
+        echo "++++ DB Migration job is successful."
+        echo "Fetching pod logs -"
+        kubectl  -n "$namespace" logs "$(kubectl -n $namespace get pods -l app=circle-migrator -o name)" > "$path"/logs/circle-migrator.log
+        echo "Pod log is available at $path/logs/circle-migrator.log"
+        echo "Removing job/circle-migrator -"
+        kubectl delete job/circle-migrator --namespace "$namespace"
+    else
+        echo "Status wait timeout for job/circle-migrator, Check the Log via - kubectl logs pods -l app=circle-migrator"
+        echo "Job circle-migrator will delete automatically after 24 hours once complete."
+    fi
+}
+
+export_postgres() {
+    PG_POD=$(kubectl -n "$NAMESPACE" get pods | grep postgresql | tail -1 | awk '{print $1}')
+    PG_PASSWORD=$(kubectl -n "$NAMESPACE" get secrets postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)
+    kubectl -n "$namepsace" exec -it "$PG_POD" -- bash -c "export PGPASSWORD='$PG_PASSWORD' && pg_dumpall -U postgres -c" > circle.sql
+}
+
+##
+# Basic sanity check / smoke test to ensure that the postgresql export performed by
+# the export_postgres function contains what we expect it to contain
+##
+function check_postgres() {
+    echo "... verifying postgres export file"
+    if [ -z "$(grep build_jobs circle.sql | head -n1)" ]
+    then
+        echo "[FATAL] Something is wrong with the postgresql export file for 'conductor_production' database, please contact CircleCI support at enterprise-support@circleci.com for further assistance."
+        exit 1
+    fi
+    if [ -z "$(grep contexts circle.sql | head -n1)" ]
+    then
+        echo "[FATAL] Something is wrong with the postgresql export file for 'contexts_service_production' database, please contact CircleCI support at enterprise-support@circleci.com for further assistance."
+        exit 1
+    fi
+    if [ -z "$(grep qrtz_blob_triggers circle.sql | head -n1)" ]
+    then
+        echo "[FATAL] Something is wrong with the postgresql export file for 'cron_service_production' database, please contact CircleCI support at enterprise-support@circleci.com for further assistance."
+        exit 1
+    fi
+    if [ -z "$(grep tasks circle.sql | head -n1)" ]
+    then
+        echo "[WARN] 'vms' database was not correctly exported."
+    fi
+}
+
+output_message(){
+    echo ""
+    echo "NOTE: After server 3.x to 4.x migration, You must rerun the Nomad terraform with modified value of 'server_endpoint' variable"
+}
+
+error_exit(){
+  msg="$*"
+
+  if [ -n "$msg" ] || [ "$msg" != "" ]; then
+    echo "------->> Error: $msg"
+  fi
+
+  kill $$
+}
+
+log_setup() {
+    path="$(cd "$(dirname "$0")" && pwd)"
+    mkdir -p "$path/logs"
+
+    exec > >(tee -a "$path/logs/$logFile") 2>&1
+
+    echo "Script Path: $path"
+}
+
+############ MAIN ############
+
+log_setup
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -n|--namespace)
+            namespace="$2";
+            shift ;;
+        -h|--help)
+            help_init_options;
+            exit 0 ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+check_prereq
+create_folders
+execute_flyway_migration
+export_postgres
+check_postgres
+output_message

--- a/migrate-3-to-4/key.sh
+++ b/migrate-3-to-4/key.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+function key_reminder() {
+    echo ""
+    echo "###########################################"
+    echo "##   Encryption & Signing keys           ##"
+
+    echo "##   must be updated in your values.yaml.  ##"
+    echo "##   Then perform a helm upgrade.          ##"
+
+    echo "###########################################"
+    echo ""
+    echo "You may find your keys here:  $(pwd)/circleci_export"
+}

--- a/migrate-3-to-4/mongo.sh
+++ b/migrate-3-to-4/mongo.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+function import_mongo() {
+    echo "Importing Mongo";
+
+    MONGO_POD="mongodb-0"
+    MONGODB_USERNAME="root"
+    MONGODB_PASSWORD=$(kubectl -n "$NAMESPACE" get secrets mongodb -o jsonpath="{.data.mongodb-root-password}" | base64 --decode)
+
+    kubectl -n "$NAMESPACE" exec "$MONGO_POD" -- mkdir -p /tmp/backups/
+    kubectl -n "$NAMESPACE" cp -v=2 "$MONGO_BU" "$MONGO_POD":/tmp/backups/
+
+    kubectl -n "$NAMESPACE" exec "$MONGO_POD" -- mongorestore --drop -u "$MONGODB_USERNAME" -p "$MONGODB_PASSWORD" --authenticationDatabase admin /tmp/backups/circle-mongo;
+    kubectl -n "$NAMESPACE" exec "$MONGO_POD" -- rm -rf /tmp/backups
+}

--- a/migrate-3-to-4/postgres.sh
+++ b/migrate-3-to-4/postgres.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+function import_postgres() {
+    echo 'Importing Postgres'
+
+    PG_POD=$(kubectl -n "$NAMESPACE" get pods | grep postgresql | tail -1 | awk '{print $1}')
+
+    PG_PASSWORD=$(kubectl -n "$NAMESPACE" get secrets postgresql -o jsonpath="{.data.postgres-password}" | base64 --decode)
+
+    # Server 3 and 4 both have a user named `postgres`.
+    # The postgres dump will drop all resources before trying to create new ones, including the postgres user.
+    # Remove the lines that would delete the postgres user.
+    # this is not a problem when migrating from 2.19 becuase 2.19's username was 'circle'
+    sed -i ".bak" '/DROP ROLE postgres/d' "$PG_BU"/circle.sql
+    sed -i ".bak" '/CREATE ROLE postgres/d' "$PG_BU"/circle.sql
+    sed -i ".bak" '/ALTER ROLE postgres WITH SUPERUSER INHERIT CREATEROLE CREATEDB LOGIN REPLICATION BYPASSRLS PASSWORD/d' "$PG_BU"/circle.sql
+
+    # Note: This import assumes `pg_dumpall -c` was run to drop tables before ...importing into them.
+    kubectl -n "$NAMESPACE" exec -i "$PG_POD" -- env PGPASSWORD="$PG_PASSWORD" psql -U postgres < "$PG_BU"/circle.sql
+}

--- a/migrate-3-to-4/preflight.sh
+++ b/migrate-3-to-4/preflight.sh
@@ -5,6 +5,7 @@
 #   make sure the namespace exists
 ##
 function preflight_checks() {
+    echo "Starting preflight checks"
     if [ -z "$NAMESPACE" ]
     then
         echo "Syntax: restore.sh <namespace>"
@@ -34,4 +35,5 @@ function preflight_checks() {
         echo "Vault data at '$VAULT_BU' not found (or is empty)"
         exit 1
     fi
+    echo "Finishing preflight checks"
 }

--- a/migrate-3-to-4/preflight.sh
+++ b/migrate-3-to-4/preflight.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+##
+# Preflight checks
+#   make sure the namespace exists
+##
+function preflight_checks() {
+    if [ -z "$NAMESPACE" ]
+    then
+        echo "Syntax: restore.sh <namespace>"
+        exit 1
+    elif [ ! "$(which kubectl)" ]
+    then
+        echo ... "'kubectl' not found"
+        exit 1
+    elif [ ! "$(which jq)" ]
+    then
+        echo ... "'jq' not found"
+        exit 1
+    elif [ "$(kubectl get namespace --no-headers "$NAMESPACE" | wc -w)" -eq 0 ]
+    then
+        echo "Namespace '$NAMESPACE' not found."
+        exit 1
+    elif [ ! -s "$PG_BU"/circle.sql ]
+    then
+        echo "Postgres data at '$PG_BU/circle.sql' not found (or is empty)"
+        exit 1
+    elif [ ! -s "$MONGO_BU"/circle-mongo ]
+    then
+        echo "Mongo data at '$MONGO_BU' not found (or is empty)"
+        exit 1
+    elif [[ ! -s "$VAULT_BU" && $(du -s "$VAULT_BU" 2>/dev/null | awk '{print $1}') -lt 5 ]]
+    then
+        echo "Vault data at '$VAULT_BU' not found (or is empty)"
+        exit 1
+    fi
+}

--- a/migrate-3-to-4/preflight.sh
+++ b/migrate-3-to-4/preflight.sh
@@ -26,7 +26,7 @@ function preflight_checks() {
     then
         echo "Postgres data at '$PG_BU/circle.sql' not found (or is empty)"
         exit 1
-    elif [ ! -s "$MONGO_BU"/circle-mongo ]
+    elif [ ! -s "$MONGO_BU" ]
     then
         echo "Mongo data at '$MONGO_BU' not found (or is empty)"
         exit 1

--- a/migrate-3-to-4/restore.sh
+++ b/migrate-3-to-4/restore.sh
@@ -16,8 +16,8 @@ source "$DIR"/vault.sh
 source "$DIR"/bottoken.sh
 # shellcheck source=migrate-3-to-4/scale.sh
 source "$DIR"/scale.sh
-# # shellcheck source=migrate/3.0-key.sh
-# source "$DIR"/3.0-key.sh
+# shellcheck source=migrate-3-to-4/key.sh
+source "$DIR"/key.sh
 
 export BACKUP_DIR="circleci_export"
 export VAULT_BU="${BACKUP_DIR}"
@@ -79,18 +79,18 @@ function circleci_database_import() {
     # wait one minute for pods to finish scaling down
     sleep 60
 
-    import_mongo
+    # import_mongo
 
-    reinject_bottoken
+    # reinject_bottoken
 
-    import_postgres
+    # import_postgres
 
     import_vault
 
     scale_deployments 1
 
-    # scale_reminder
-    # key_reminder
+    scale_reminder
+    key_reminder
 }
 
 

--- a/migrate-3-to-4/restore.sh
+++ b/migrate-3-to-4/restore.sh
@@ -6,10 +6,10 @@ DIR=$(dirname "$0")
 
 # shellcheck source=migrate-3-to-4/preflight.sh
 source "$DIR"/preflight.sh
-# # shellcheck source=migrate/3.0-postgres.sh
-# source "$DIR"/3.0-postgres.sh
-# # shellcheck source=migrate/3.0-mongo.sh
-# source "$DIR"/3.0-mongo.sh
+# shellcheck source=migrate-3-to-4/postgres.sh
+source "$DIR"/postgres.sh
+# shellcheck source=migrate/3.0-mongo.sh
+source "$DIR"/mongo.sh
 # # shellcheck source=migrate/3.0-vault.sh
 # source "$DIR"/3.0-vault.sh
 # # shellcheck source=migrate/3.0-bottoken.sh
@@ -21,7 +21,7 @@ source "$DIR"/scale.sh
 
 export BACKUP_DIR="circleci_export"
 export VAULT_BU="${BACKUP_DIR}/vault"
-export MONGO_BU="${BACKUP_DIR}"
+export MONGO_BU="${BACKUP_DIR}/circle-mongo"
 export PG_BU="${BACKUP_DIR}"
 
 ARGS="${*:1}"
@@ -83,7 +83,7 @@ function circleci_database_import() {
 
     # reinject_bottoken
 
-    # import_postgres
+    import_postgres
 
     # import_vault
 

--- a/migrate-3-to-4/restore.sh
+++ b/migrate-3-to-4/restore.sh
@@ -10,8 +10,8 @@ source "$DIR"/preflight.sh
 source "$DIR"/postgres.sh
 # shellcheck source=migrate/3.0-mongo.sh
 source "$DIR"/mongo.sh
-# # shellcheck source=migrate/3.0-vault.sh
-# source "$DIR"/3.0-vault.sh
+# shellcheck source=migrate-3-to-4/vault.sh
+source "$DIR"/vault.sh
 # # shellcheck source=migrate/3.0-bottoken.sh
 # source "$DIR"/3.0-bottoken.sh
 # shellcheck source=migrate-3-to-4/scale.sh
@@ -20,7 +20,7 @@ source "$DIR"/scale.sh
 # source "$DIR"/3.0-key.sh
 
 export BACKUP_DIR="circleci_export"
-export VAULT_BU="${BACKUP_DIR}/vault"
+export VAULT_BU="${BACKUP_DIR}"
 export MONGO_BU="${BACKUP_DIR}/circle-mongo"
 export PG_BU="${BACKUP_DIR}"
 
@@ -85,11 +85,9 @@ function circleci_database_import() {
 
     import_postgres
 
-    # import_vault
+    import_vault
 
-    # scale_deployments 1
-
-    # echo "CircleCI Server Import Complete"
+    scale_deployments 1
 
     # scale_reminder
     # key_reminder

--- a/migrate-3-to-4/restore.sh
+++ b/migrate-3-to-4/restore.sh
@@ -12,8 +12,8 @@ source "$DIR"/postgres.sh
 source "$DIR"/mongo.sh
 # shellcheck source=migrate-3-to-4/vault.sh
 source "$DIR"/vault.sh
-# # shellcheck source=migrate/3.0-bottoken.sh
-# source "$DIR"/3.0-bottoken.sh
+# shellcheck source=migrate-3-to-4/bottoken.sh
+source "$DIR"/bottoken.sh
 # shellcheck source=migrate-3-to-4/scale.sh
 source "$DIR"/scale.sh
 # # shellcheck source=migrate/3.0-key.sh
@@ -81,7 +81,7 @@ function circleci_database_import() {
 
     import_mongo
 
-    # reinject_bottoken
+    reinject_bottoken
 
     import_postgres
 

--- a/migrate-3-to-4/restore.sh
+++ b/migrate-3-to-4/restore.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+set -e
+
+DIR=$(dirname "$0")
+
+# shellcheck source=migrate-3-to-4/preflight.sh
+source "$DIR"/preflight.sh
+# # shellcheck source=migrate/3.0-postgres.sh
+# source "$DIR"/3.0-postgres.sh
+# # shellcheck source=migrate/3.0-mongo.sh
+# source "$DIR"/3.0-mongo.sh
+# # shellcheck source=migrate/3.0-vault.sh
+# source "$DIR"/3.0-vault.sh
+# # shellcheck source=migrate/3.0-bottoken.sh
+# source "$DIR"/3.0-bottoken.sh
+# # shellcheck source=migrate/3.0-scale.sh
+# source "$DIR"/3.0-scale.sh
+# # shellcheck source=migrate/3.0-key.sh
+# source "$DIR"/3.0-key.sh
+
+export BACKUP_DIR="circleci_export"
+export VAULT_BU="${BACKUP_DIR}/vault"
+export MONGO_BU="${BACKUP_DIR}"
+export PG_BU="${BACKUP_DIR}"
+
+ARGS="${*:1}"
+
+# Init
+
+help_init_options() {
+    # Help message for Init menu
+    echo "  -h|--help                     Print help text"
+}
+
+init_options() {
+    # Handles arguments passed into the init menu
+    POSITIONAL=()
+    while [[ $# -gt 0 ]]
+    do
+    key="${1}"
+    case $key in
+        -h|--help)
+            help_init_options
+            exit 0
+        ;;
+        -*)     # unknown option
+            if [ -n "$1" ] ;
+            then
+                POSITIONAL+=("${1}") # save it in an array for later
+            fi
+            shift
+        ;;
+        *)          # namespace
+            export NAMESPACE
+            NAMESPACE=$(echo "${1}" | xargs)
+            shift
+        ;;
+    esac
+    done
+
+    if [ ${#POSITIONAL[@]} -gt 0 ]
+    then
+        help_init_options
+        exit 1
+    fi
+}
+
+function circleci_database_import() {
+    echo "Starting CircleCI Database Import"
+
+    preflight_checks
+
+    echo "done"
+
+    # if [ ! "$SKIP_MONGO $SKIP_POSTGRES $SKIP_VAULT" = "true true true" ];
+    # then
+    #     echo "...scaling application deployments to 0..."
+    #     scale_deployments 0
+
+    #     # if postgres is internal, delete pod to clear any remaining connections
+    #     if [ ! "$SKIP_POSTGRES" = "true" ];
+    #     then
+    #         kubectl delete pod -l app.kubernetes.io/name=postgresql -n "$NAMESPACE"
+    #     fi
+
+    #     # wait one minute for pods to scale down
+    #     sleep 60
+    # fi
+
+    # if [ ! "$SKIP_MONGO" = "true" ];
+    # then
+    #     MONGO_BU="${BACKUP_DIR}/circleci-mongo-export"
+    #     import_mongo
+
+    #     reinject_bottoken
+    # fi
+
+    # if [ ! "$SKIP_POSTGRES" = "true" ];
+    # then
+    #     PG_BU="${BACKUP_DIR}/circleci-pg-export"
+    #     import_postgres
+    # fi
+
+    # if [ ! "$SKIP_VAULT" = "true" ];
+    # then
+    #     VAULT_BU="${BACKUP_DIR}/circleci-vault"
+    #     import_vault
+    # fi
+
+    # if [ ! "$SKIP_MONGO $SKIP_POSTGRES $SKIP_VAULT" = "true true true" ];
+    # then
+    #     echo "...scaling application deployments to 1..."
+    #     scale_deployments 1
+    # fi
+
+    # echo "CircleCI Server Import Complete"
+
+    # scale_reminder
+    # key_reminder
+}
+
+
+# shellcheck disable=SC2086
+init_options $ARGS
+circleci_database_import

--- a/migrate-3-to-4/restore.sh
+++ b/migrate-3-to-4/restore.sh
@@ -8,7 +8,7 @@ DIR=$(dirname "$0")
 source "$DIR"/preflight.sh
 # shellcheck source=migrate-3-to-4/postgres.sh
 source "$DIR"/postgres.sh
-# shellcheck source=migrate/3.0-mongo.sh
+# shellcheck source=migrate-3-to-4/mongo.sh
 source "$DIR"/mongo.sh
 # shellcheck source=migrate-3-to-4/vault.sh
 source "$DIR"/vault.sh
@@ -79,7 +79,7 @@ function circleci_database_import() {
     # wait one minute for pods to finish scaling down
     sleep 60
 
-    # import_mongo
+    import_mongo
 
     # reinject_bottoken
 

--- a/migrate-3-to-4/restore.sh
+++ b/migrate-3-to-4/restore.sh
@@ -79,11 +79,11 @@ function circleci_database_import() {
     # wait one minute for pods to finish scaling down
     sleep 60
 
-    # import_mongo
+    import_mongo
 
-    # reinject_bottoken
+    reinject_bottoken
 
-    # import_postgres
+    import_postgres
 
     import_vault
 

--- a/migrate-3-to-4/scale.sh
+++ b/migrate-3-to-4/scale.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Function to scale the deployments in a CCI cluster
+# pass the number to scale to as the first argument
+scale_deployments() {
+    number=$1
+
+    if [ -n "$number" ]
+    then
+
+        echo "Scaling application deployments to ${number}"
+        kubectl -n "$NAMESPACE" get deploy --no-headers -l "layer=application" | awk '{print $1}' | xargs -I echo -- kubectl -n "$NAMESPACE" scale deploy echo --replicas="$number"
+    else
+        echo "A number of replicas must be passed as an argument to scale_deployments"
+        exit 1
+    fi
+}
+
+scale_reminder() {
+    echo "Please note all deployments have been scaled to 1."
+    echo "This is not necessarily desirable in all scenarios."
+    echo "Consider scaling some deployments for high availability ."
+}

--- a/migrate-3-to-4/temp-vault-pod.yml
+++ b/migrate-3-to-4/temp-vault-pod.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: temp-vault
+  labels:
+    app: temp-vault  
+spec:
+  containers:
+    - name: temp-vault
+      image: busybox
+      command: [ "/bin/sh", "-c", "sleep 7200" ]
+      volumeMounts:
+      - mountPath: "/tmp/vault/file" # Folder in pod mounting nfsclaim
+        name: myvol
+  volumes:
+    - name: myvol             # volume name the container can mount
+      persistentVolumeClaim:   # Source of storage
+        claimName: data-vault-0  # name of pvc created

--- a/migrate-3-to-4/templates/circle-migrator.yaml
+++ b/migrate-3-to-4/templates/circle-migrator.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: circle-migrator
+  labels:
+    app: circle-migrator
+    layer: application
+spec:
+  ttlSecondsAfterFinished: 86400   # 24- hrs
+  template:
+    metadata:
+      labels:
+        app: circle-migrator
+    spec:
+      imagePullSecrets:
+      - name: regcred
+      containers:
+      - name: circle-migrator
+        image: cciserver.azurecr.io/circle-migrator:0.1.532114-6a5071e0ed
+        env:
+        - name: FLYWAY_BASELINE_ON_MIGRATE
+          value: "true"
+        - name: POSTGRESQL_HOST
+          value: "$POSTGRES_HOST"
+        - name: POSTGRESQL_PORT
+          value: "$POSTGRES_PORT"
+        - name: POSTGRESQL_USERNAME
+          value: "$POSTGRES_USERNAME"
+        - name: POSTGRESQL_PASSWORD
+          value: "$POSTGRES_PASSWORD"
+        - name: DATABASE_URL
+          value: "jdbc:postgresql://$(POSTGRESQL_HOST):$(POSTGRESQL_PORT)/domain?user=$(POSTGRESQL_USERNAME)&password=$(POSTGRESQL_PASSWORD)"
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 100Mi
+          requests:
+            cpu: 2m
+            memory: 10Mi
+      restartPolicy: Never

--- a/migrate-3-to-4/vault-pvc.yml
+++ b/migrate-3-to-4/vault-pvc.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-vault-0
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 8Gi

--- a/migrate-3-to-4/vault.sh
+++ b/migrate-3-to-4/vault.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -e
+
+function import_vault() {
+    echo "Importing Vault"
+
+    VAULT_STS="vault"
+    VAULT_POD="vault-0"
+    VAULT_PVC="data-vault-0"
+    TEMP_VAULT_POD="temp-vault"
+    TEMP_VAULT_POD_YAML="temp-vault-pod.yml"
+    VAULT_PVC_YAML="vault-pvc.yml"
+
+    # Scaling down Vault
+    kubectl -n "$NAMESPACE" scale --replicas=0 sts/$VAULT_STS
+
+    # Waiting for Vault termination
+    while [[ $(kubectl -n "$NAMESPACE" get pods -l app="$VAULT_STS" 2>/dev/null | grep -c "$VAULT_STS") -gt 0 ]]
+    do
+        echo "Vault is terminating"
+        sleep 15
+    done
+
+    # Deleting the PVC
+    kubectl -n "$NAMESPACE" delete pvc/$VAULT_PVC
+
+    # Recreating the PVC
+    kubectl -n "$NAMESPACE" apply -f "$VAULT_PVC_YAML"
+
+    # Creating a test pod
+    kubectl -n "$NAMESPACE" apply -f "$TEMP_VAULT_POD_YAML"
+
+    # Waiting for Pod temp-vault
+    while [[ ! $(kubectl -n "$NAMESPACE" get pods -l app="$TEMP_VAULT_POD" 2>/dev/null | grep -c "1/1") -gt 0 ]]
+    do
+        echo "Waiting for $TEMP_VAULT_POD to scale up"
+        sleep 15
+    done
+
+    # Copy the vault backup into test pod
+    kubectl -n "$NAMESPACE" cp -v=2 "$VAULT_BU"/vault-backup.tar.gz "$TEMP_VAULT_POD":/tmp/vault-backup.tar.gz
+
+    # Extract the content
+    kubectl -n "$NAMESPACE" exec "$TEMP_VAULT_POD" -- tar -xvzf /tmp/vault-backup.tar.gz -C /tmp/vault/
+    kubectl -n "$NAMESPACE" exec "$TEMP_VAULT_POD" -- cp -r /tmp/vault/circleci_export/file /tmp/vault
+
+    # Check if content is extracted
+    kubectl -n "$NAMESPACE" exec "$TEMP_VAULT_POD" -- ls -al /tmp/vault/ /tmp/vault/file
+
+    # If Yes, delete the pod now
+    kubectl -n "$NAMESPACE" delete pod/"$TEMP_VAULT_POD"
+
+    # Bring up the Vault sts and wait to be up
+    kubectl -n "$NAMESPACE" scale --replicas=1 sts/$VAULT_STS
+
+    # Waiting for Pod vault
+    while [[ ! $(kubectl -n "$NAMESPACE" get pods -l app="$VAULT_STS" 2>/dev/null | grep -c "2/2") -gt 0 ]]
+    do
+        echo "Waiting for $VAULT_STS to scale up"
+        sleep 15
+    done
+
+    kubectl -n "$NAMESPACE" get pods -l app="$VAULT_STS"
+
+    ### Unseal
+    kubectl -n "$NAMESPACE" exec "$VAULT_POD" -c vault -- sh -c "rm -rf /vault/file/sys/expire/id/auth/token/create/* && for k in \$(head -n 3 /vault/file/vault-init-out | sed \"s/^.*: //g\"); do vault operator unseal \"\$k\"; done; vault login \$(grep \"Root\" /vault/file/vault-init-out | sed \"s/^.*: //g\"); vault token create -period=\"768h\" > /vault/file/client-token; grep \"token \" /vault/file/client-token | sed \"s/^token\W*//g\" > /vault/__restricted/client-token"
+}


### PR DESCRIPTION
:gear: **Issue**

Sometimes KOTS does not have the expected helm application installed.  In this case we need to do the migration to 4.0 a different way.

:white_check_mark: **Fix**

Migrate from 3.4 to 4.0 with database migrations between 2 separate installations.

Very little of this is net new work.  It is mostly copy pasted from the 2.19 migration scripts.
I prioritized minimizing changes over beautiful and concise code.  Also, this is currently to solve a problem for one customer and is unlikely to see use beyond that.

To make your review easier, consider reviewing each commit individually, or comparing the files to what they were copied from:

migrate-3-to-4/exporter.sh - kots-exporter/kots-exporter.sh
migrate-3-to-4/bottoken.sh - migrate/3.0-bottoken.sh
migrate-3-to-4/key.sh - migrate/3.0-key.sh
migrate-3-to-4/mongo.sh - migrate/3.0-mongo.sh
migrate-3-to-4/postgres.sh - migrate/3.0-postgres.sh
migrate-3-to-4/prefligh.sh - migrate/3.0-preflight.sh
migrate-3-to-4/scale.sh - migrate/3.0-scale.sh
migrate-3-to-4/vault.sh - migrate/3.0-vault.sh
migrate-3-to-4/restore.sh - migrate/3.0-restore.sh

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- tested the migration between new 3.4 and 4.0 instances
