### PR TITLE
fix: pass namespace when listing Helm releases

### DIFF
--- a/kots-exporter/kots-exporter.sh
+++ b/kots-exporter/kots-exporter.sh
@@ -65,16 +65,16 @@ check_prereq(){
 check_postreq(){
     echo ""
     echo "############ CHECKING K8S NAMESPACE and HELM RELEASE ################"
-    # check if helm release exists
-    if  [[ "$(helm list -n $namespace -o yaml  | yq '.[].name')" != "$slug" ]]
-    then
-        error_exit "Helm release $slug does not exist."
-    fi
-
     # check if namespace exists
     if ! kubectl get ns "$namespace" -o name > /dev/null 2>&1
     then
         error_exit "Namespace $namespace does not exist in k8s cluster."
+    fi
+
+    # check if helm release exists
+    if  [[ "$(helm list -n $namespace -o yaml  | yq '.[].name')" != "$slug" ]]
+    then
+        error_exit "Helm release $slug does not exist."
     fi
 
     # check if secret/regcred exists

--- a/kots-exporter/kots-exporter.sh
+++ b/kots-exporter/kots-exporter.sh
@@ -66,7 +66,7 @@ check_postreq(){
     echo ""
     echo "############ CHECKING K8S NAMESPACE and HELM RELEASE ################"
     # check if helm release exists
-    if  [[ "$(helm list -o yaml  | yq '.[].name')" != "$slug" ]]
+    if  [[ "$(helm list -n $namespace -o yaml  | yq '.[].name')" != "$slug" ]]
     then
         error_exit "Helm release $slug does not exist."
     fi


### PR DESCRIPTION
:gear: **Issue**

I was unable to run the kots-exporter.sh script when my Helm app is installed in a different k8s namespace other than circleci-server (default).
I see the following error:

```
------->> Error: Helm release circleci-server does not exist.
```

This occurred even when specifying the namespace via the `-n <namespace>` option.

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->

This fix ensures the `helm list` command looks up the specified namespace.

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [x] Tested Updating Existing Instance
- [ ] Installed on new instance

I tested this worked to the point of the following outputs:

```
$ ./kots-exporter.sh
Script Path: /Users/kelvin/personal/server-scripts/kots-exporter


############ CHECKING REQUIRED ARGUMENTS ################
KOTS admin namespace (circleci-server): circleci
License Key String: jdslakldklk;ad

############ SET DEFAULT VALUES ################

############ CHECKING K8S NAMESPACE and HELM RELEASE ################

############ CREATING FOLDERS ################
output folder has been created.

############ DOWNLOADING HELM VALUE ################

Downloading helm value file from release: circleci-server and namespace: circleci
++++ Helm value file download has completed
```