### PR TITLE
fix: Missing some quotes for shellcheck

### DIFF
--- a/kots-exporter/kots-exporter.sh
+++ b/kots-exporter/kots-exporter.sh
@@ -72,7 +72,7 @@ check_postreq(){
     fi
 
     # check if helm release exists
-    if  [[ "$(helm list -n $namespace -o yaml  | yq '.[].name')" != "$slug" ]]
+    if  [[ "$(helm list -n "$namespace" -o yaml  | yq '.[].name')" != "$slug" ]]
     then
         error_exit "Helm release $slug does not exist."
     fi


### PR DESCRIPTION
We were just missing a couple quotes. Nothing major.