### PR TITLE
fix: look up app slug in list of Helm apps

### DIFF
--- a/kots-exporter/kots-exporter.sh
+++ b/kots-exporter/kots-exporter.sh
@@ -72,7 +72,7 @@ check_postreq(){
     fi
 
     # check if helm release exists
-    if  [[ "$(helm list -n "$namespace" -o yaml  | yq '.[].name')" != "$slug" ]]
+    if  [[ "$(helm list -n "$namespace" -o yaml  | yq -e 'map(.name) | contains([strenv(slug)])' > /dev/null 2>&1)" ]]
     then
         error_exit "Helm release $slug does not exist."
     fi


### PR DESCRIPTION
:gear: **Issue**

When the k8s namespace has more than 1 Helm app installed, the kots-exporter will fail since the following command will return multilines.

```console
$ helm list -n circleci -o yaml | yq '.[].name'
circleci-server
helloworld
```

<!-- What's wrong; why the change? A good place to reference the ticket if it exists. -->

:white_check_mark: **Fix** 

I modified the yq command, using `yq` operators, to look up the list of Helm apps by name.
This fixes the case where the k8s namespace contains >1 Helm app.

- `-e` for `--exit-status`
- `contains` to look up an array: https://mikefarah.gitbook.io/yq/operators/contains
- `strenv` to load the `$slug` env var: https://mikefarah.gitbook.io/yq/operators/env-variable-operators#read-boolean-environment-variable-as-a-string


<!-- How did you fix the issue? -->

### Context

```console
$ helm list -n circleci -o yaml | yq '.[].name'
circleci-server
helloworld
```

### Before

```console
$ ./kots-exporter/kots-exporter.sh -n circleci
Script Path: /Users/kelvin/personal/kelvintaywl-server-scripts/kots-exporter


############ CHECKING REQUIRED ARGUMENTS ################
License Key String: asdjkla

############ SET DEFAULT VALUES ################

############ CHECKING K8S NAMESPACE and HELM RELEASE ################
------->> Error: Helm release circleci-server does not exist.
[1]    20279 terminated  ./kots-exporter/kots-exporter.sh -n circleci
```

### After

```console
$ ./kots-exporter/kots-exporter.sh -n circleci
Script Path: /Users/kelvin/personal/kelvintaywl-server-scripts/kots-exporter


############ CHECKING REQUIRED ARGUMENTS ################
License Key String: asdjkla

############ SET DEFAULT VALUES ################

############ CHECKING K8S NAMESPACE and HELM RELEASE ################

############ CREATING FOLDERS ################
output folder has been created.

############ DOWNLOADING HELM VALUE ################

Downloading helm value file from release: circleci-server and namespace: circleci
++++ Helm value file download has completed
....
```


<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [x] Tested Updating Existing Instance
- [ ] Installed on new instance
