### PR TITLE
feat: Vault to Tink migration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ This repository contains various tools and scripts which supports CircleCI serve
 ### [support](./support/)
 
 `support` directory contains support-bundle template and instruction to generate support-bundle.
+
+### [vault-to-tink](./vault-to-tink/)
+
+`vault-to-tink` enables a migration from a Vault installation to a (Google) Tink installation.

--- a/vault-to-tink/README.md
+++ b/vault-to-tink/README.md
@@ -1,0 +1,47 @@
+# Vault to Tink
+
+## Prerequisites
+
+1. The public internet is accessible OR lein dependencies are pre-cached
+1. The kubectl context needs to be in the correct namespace (`kubectl config set-context --current --namespace <namespace>`)
+1. Docker is running and accessible to run the `clojure` container
+1. The Postgres server is internal to the CircleCI installation
+
+   - If Postgres has been externalized, please reach out to your account representitive.
+
+1. You have a Tink keyset ready to go with `tinkey create-keyset --key-template XCHACHA20_POLY1305`
+
+Note: This script will open one REPL per context ID, where one ID is one context; not to be confused with individual variables within a context. If you have a firewall that will rate-limit you, please take that into consideration before proceeding.
+
+Warning: There will be downtime for jobs using contexts during this migration; specifically after updating the `values.yaml` and before the import script finishes.
+
+Warning: Exporting contexts will create a file on your system named `contexts.json`. This file will contain all the names and values of your secrets. It is strongly recommended to `rm -f contexts.json` after importing the contexts and verifying the system operates as expected.
+
+## Preparation
+
+1. Run a job that uses contexts and verify it worked as expected.
+
+## Export
+
+1. Navigate to this directory in your terminal
+1. Run `bash export-contexts.sh`
+
+## Moving to Tink
+
+1. Update your `values.yaml` to reference Tink and disable Vault:
+
+```
+tink:
+  enabled: true
+  keyset: '{"primaryKeyId":1981846258,"key":[{"keyData":{"typeUrl":"type.googleapis.com/google.crypto.tink.XChaCha20Poly1305Key","value":"GiCibSVjG2+bLaeShz+M67BcsEZt7GPI+zcE8J+HKYew==","keyMaterialType":"SYMMETRIC"},"status":"ENABLED","keyId":1981846258,"outputPrefixType":"TINK"}]}'
+vault:
+  internal: false
+```
+
+## Import
+
+1. Run `bash import-contexts.sh`
+
+## Verification
+
+1. Trigger the same pipeline as the preparation phase to ensure contexts work as expected. _If things do not work as expected, please reach out to your account representitive._

--- a/vault-to-tink/README.md
+++ b/vault-to-tink/README.md
@@ -9,7 +9,7 @@
 
    - If Postgres has been externalized, please reach out to your account representitive.
 
-1. You have a Tink keyset ready to go with `tinkey create-keyset --key-template XCHACHA20_POLY1305`
+1. You have a [Tink keyset](https://developers.google.com/tink/install-tinkey) ready to go with `tinkey create-keyset --key-template XCHACHA20_POLY1305`
 
 Note: This script will open one REPL per context ID, where one ID is one context; not to be confused with individual variables within a context. If you have a firewall that will rate-limit you, please take that into consideration before proceeding.
 

--- a/vault-to-tink/README.md
+++ b/vault-to-tink/README.md
@@ -40,7 +40,7 @@ vault:
 
 ## Import
 
-1. Run `bash import-contexts.sh`
+1. Run `bash import-contexts.sh [--hostname <circleci-hostname>] [--token <circleci-token>]`
 
 ## Verification
 

--- a/vault-to-tink/export-contexts.sh
+++ b/vault-to-tink/export-contexts.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# NOTES:
+# This script will assume:
+# * lein dependencies are pre-cached OR the internet is accessible
+# * we have modified the kubectl context to be in the correct namespace (kubectl config set-context --current --namespace <namespace>)
+# * Docker is running & can be utilized without sudo
+# * the Postgres server is internal to the CircleCI installation
+
+SVC_NAME=contexts-service
+SVC_PORT=6005
+
+rm -f contexts.json
+touch contexts.json
+
+INET_ADDR="$(ip -4 route get 192.0.2.1 | grep -o 'src [0-9.]\{1,\}' | awk '{ print $2 }')"
+if [ -z "$INET_ADDR" ]; then
+  echo "Unable to determine IP address"
+  exit 1
+fi
+
+kubectl port-forward "$(kubectl get po -l app="${SVC_NAME}" -o jsonpath='{.items[0].metadata.name}')" --address "${INET_ADDR}" "${SVC_PORT}" 1>/dev/null 2>&1 &
+PORT_FORWARD_SUCCESS=$?
+
+if [ "${PORT_FORWARD_SUCCESS}" -ne 0 ]; then
+  echo "Unable to port-forward to ${SVC_NAME}"
+  exit 1
+fi
+
+CONTEXTS=$(kubectl exec -it postgresql-0 -- bash -c "PGPASSWORD=\$POSTGRES_PASSWORD psql -t -U postgres -d contexts_service_production -c \"select id,owning_grouping_ref from contexts\";" | grep -e - | sed -e 's/[ \t]|[ \t]/,/g')
+
+for CONTEXT in $CONTEXTS; do
+  CONTEXT_ID=$(echo "${CONTEXT}" | awk -F, '{print $1}')
+  GROUPING_ID=$(echo "${CONTEXT}" | awk -F, '{print $2}' | sed "s|[\r\n]||g")
+
+  CLOJURE=$(printf "(let [obj (first (contexts-service.db/get-contexts \\\"%s\\\"))]
+              (let [org-ref (:contexts-service-client.context.response/organization-ref obj)
+                    resources (:contexts-service-client.context.response/resources obj)
+                    keyvals (map (fn [res] {:name (:contexts-service-client.context/variable res)
+                                          :value (:contexts-service-client.context/value res)})
+                                resources)]
+                (cheshire.core/generate-string {
+                                      :organization-ref org-ref
+                                      :context-id \\\"%s\\\"
+                                      :contexts keyvals})))" "${GROUPING_ID}" "${CONTEXT_ID}")
+
+  docker run --rm -it clojure \
+    bash -c "lein repl :connect \"${INET_ADDR}\":6005 <<< '${CLOJURE}'" |
+    grep '"{\\"organization-ref' |
+    jq -r \
+      >>contexts.json
+done

--- a/vault-to-tink/export-contexts.sh
+++ b/vault-to-tink/export-contexts.sh
@@ -10,8 +10,7 @@
 SVC_NAME=contexts-service
 SVC_PORT=6005
 
-rm -f contexts.json
-touch contexts.json
+echo -n > contexts.json
 
 INET_ADDR="$(ip -4 route get 192.0.2.1 | grep -o 'src [0-9.]\{1,\}' | awk '{ print $2 }')"
 if [ -z "$INET_ADDR" ]; then

--- a/vault-to-tink/import-contexts.sh
+++ b/vault-to-tink/import-contexts.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Read the --hostname argument and --token arguments
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+  --hostname)
+    CIRCLECI_HOSTNAME="$2"
+    shift
+    shift
+    ;;
+  --token)
+    CIRCLECI_TOKEN="$2"
+    shift
+    shift
+    ;;
+  *)
+    echo "Unknown argument: $1"
+    exit 1
+    ;;
+  esac
+done
+# Prompt the user for the CircleCI server hostname if there was no argument
+if [ -z "${CIRCLECI_HOSTNAME}" ]; then
+  read -rp "CircleCI server hostname: " CIRCLECI_HOSTNAME
+fi
+
+# Verify the hostname is not empty
+if [ -z "${CIRCLECI_HOSTNAME}" ]; then
+  echo "CircleCI server hostname cannot be empty"
+  exit 1
+fi
+
+# Prompt the user for the CircleCI token if there was no argument
+if [ -z "${CIRCLECI_TOKEN}" ]; then
+  read -rp "CircleCI API token: " CIRCLECI_TOKEN
+fi
+
+# Verify the token is not empty
+if [ -z "${CIRCLECI_TOKEN}" ]; then
+  echo "CircleCI API token cannot be empty"
+  exit 1
+fi
+
+# Check if contexts.json is empty
+if [ ! -s contexts.json ]; then
+  echo "No contexts found"
+  exit 1
+fi
+
+AUTH=$(printf "%s" "${CIRCLECI_TOKEN}:" | base64)
+
+for obj in $(jq -c . contexts.json); do
+  # extract the context-id
+  context_id=$(echo "${obj}" | jq -r '.["context-id"]')
+
+  # iterate over each context in the contexts array
+  for ctx in $(echo "${obj}" | jq -c '.["contexts"][]'); do
+    # extract the name and value of the context
+    name=$(echo "${ctx}" | jq -r '.["name"]')
+    value=$(echo "${ctx}" | jq '.["value"]')
+
+    # Post the data to the CircleCI server API
+    # (echo for debug purposes)
+    curl --request PUT \
+      --url "https://${CIRCLECI_HOSTNAME}/api/v2/context/${context_id}/environment-variable/${name}" \
+      --header "Authorization: Basic ${AUTH}" \
+      --header "Content-Type: application/json" \
+      --data "{\"value\":${value}}"
+  done
+done


### PR DESCRIPTION
The export script leaves very sensitive data behind, and the migration will incur some downtime for jobs that use contexts, but the risk is minimal. With that said, please make a backup first anyway.

WANTED: A way to dry-run at least the export (where we'd maybe export the names in contexts and not the values)

:gear: **Issue**

Our Vault story is not great so we're moving to Tink instead.

SERVER-2432

:white_check_mark: **Fix**

Introducing: a script to move your installation from Vault to Tink!

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [X] Tested Updating Existing Instance
- [ ] Installed on new instance
