### PR TITLE
Typo fixes in kots-exporter and migratre-3-to-4 README docs

### DIFF
--- a/kots-exporter/README.md
+++ b/kots-exporter/README.md
@@ -1,4 +1,4 @@
-# server-kots-exportergs
+# server-kots-exporter
 
 This is a script to download KOTS config and convert it to a `helm` values file
 
@@ -9,13 +9,14 @@ This is a script to download KOTS config and convert it to a `helm` values file
 - [helm-diff](https://github.com/databus23/helm-diff#install) (Good to have for comparing helm releases)
 - [velero](https://velero.io/docs/v1.6/contributions/minio/#back-up) (Required for backup and restore)
 
-### Docker secret `regcred` must be exists
-The Helm chart references private container images. The DockerHub
+### A Docker secret `regcred` must exist in your namespace
+
+The Helm chart references private CircleCI container images. The DockerHub
 API token you've been supplied will allow you to pull these images. To do so we need
-to create a Docker registry secret in your Kubernetes cluster:
+to create a Docker registry secret in your Kubernetes cluster namespace:
 
 ```
-$ kubectl create secret docker-registry regcred \
+$ kubectl create secret docker-registry -n <circleci-app-namespace> regcred \
   --docker-server=https://cciserver.azurecr.io/ \
   --docker-username=<image-registry-username> \
   --docker-password=<image-registry-password> \

--- a/kots-exporter/README.md
+++ b/kots-exporter/README.md
@@ -16,7 +16,7 @@ API token you've been supplied will allow you to pull these images. To do so we 
 to create a Docker registry secret in your Kubernetes cluster namespace:
 
 ```
-$ kubectl create secret docker-registry -n <circleci-app-namespace> regcred \
+$ kubectl create secret docker-registry -n <circleci-namespace> regcred \
   --docker-server=https://cciserver.azurecr.io/ \
   --docker-username=<image-registry-username> \
   --docker-password=<image-registry-password> \

--- a/kots-exporter/README.md
+++ b/kots-exporter/README.md
@@ -28,7 +28,7 @@ $ kubectl create secret docker-registry -n <circleci-namespace> regcred \
 
 **view arguments:** `./kots-exporter.sh --help`
 
-**command:** `./kots-exporter.sh -n <circleci-app-namespace> -a <release-name> -l <license>`
+**command:** `./kots-exporter.sh -n <circleci-namespace> -a <release-name> -l <license>`
 
 **example usage:**
 ```

--- a/migrate-3-to-4/README.md
+++ b/migrate-3-to-4/README.md
@@ -1,7 +1,7 @@
 # Migrating 3 to 4
 **Stop!** You probably want [kots-exporter](../kots-exporter/).  This script should only be used at the recommendation of your CircleCI Contact.
 
-## Prequsites
+## Prerequsites
 1. There exists a 4.0 instance where reality check has successfully run.
 
 2. In the 3.4 environment, add the same [docker-registry secret](https://circleci.com/docs/server/installation/phase-2-core-services/#pull-images) that is used in the 4.0 environment

--- a/migrate-3-to-4/README.md
+++ b/migrate-3-to-4/README.md
@@ -1,7 +1,7 @@
 # Migrating 3 to 4
 **Stop!** You probably want [kots-exporter](../kots-exporter/).  This script should only be used at the recommendation of your CircleCI Contact.
 
-## Prerequsites
+## Prerequisites
 1. There exists a 4.0 instance where reality check has successfully run.
 
 2. In the 3.4 environment, add the same [docker-registry secret](https://circleci.com/docs/server/installation/phase-2-core-services/#pull-images) that is used in the 4.0 environment


### PR DESCRIPTION
:gear: **Issue**

- Noticed a few typos in the `README.md` files for [kots-exporter](https://github.com/CircleCI-Public/server-scripts/tree/main/kots-exporter#server-kots-exportergs) and the [migrate-3-to-4](https://github.com/CircleCI-Public/server-scripts/tree/main/migrate-3-to-4#prequsites) section of the `migrate-3-to-4` folder. 
- Added `-n <circle-app-namespace>` to the create `regcred` secret command in the [kots-exporter](https://github.com/CircleCI-Public/server-scripts/tree/main/kots-exporter) README page for more clarity. We have had a couple of instances where customers ran it in their default namespace without the `-n` reference, resulting in a few extra steps that could have been avoided. 


:white_check_mark: **Fix**

- Minor typo fixes and README changes. No changes to migration scripts. 

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [ ] Tested Updating Existing Instance
- [ ] Installed on new instance
