### PR TITLE
migrate-3-to-4: use mongo data volume for backup

### DIFF
--- a/migrate-3-to-4/exporter.sh
+++ b/migrate-3-to-4/exporter.sh
@@ -134,10 +134,11 @@ export_mongo() {
     MONGO_POD="mongodb-0"
     MONGODB_USERNAME="root"
     MONGODB_PASSWORD=$(kubectl -n "$namespace" get secrets mongodb -o jsonpath="{.data.mongodb-root-password}" | base64 --decode)
-    TEMP_DIR="/bitnami/circle-mongo"
+    TEMP_DIR="/bitnami/mongodb/circle-mongo"
     kubectl -n "$namespace" exec -it "$MONGO_POD" -- bash -c "mkdir $TEMP_DIR"
     kubectl -n "$namespace" exec -it "$MONGO_POD" -- bash -c "mongodump -u '$MONGODB_USERNAME' -p '$MONGODB_PASSWORD' --authenticationDatabase admin --db=circle_ghe --out=$TEMP_DIR"
     kubectl -n "$namespace" cp $MONGO_POD:$TEMP_DIR ${BACKUP_DIR}/circle-mongo
+    kubectl -n "$namespace" exec -it "$MONGO_POD" -- bash -c "rm -rf $TEMP_DIR"
 }
 
 export_vault() {

--- a/migrate-3-to-4/mongo.sh
+++ b/migrate-3-to-4/mongo.sh
@@ -5,7 +5,7 @@ function import_mongo() {
 
     MONGO_POD="mongodb-0"
     MONGODB_USERNAME="root"
-    MONGODB_PASSWORD=$(kubectl -n "$NAMESPACE" get secrets mongodb-credentials -o jsonpath="{.data.mongodb-root-password}" | base64 --decode)
+    MONGODB_PASSWORD=$(kubectl -n "$NAMESPACE" get secrets mongodb -o jsonpath="{.data.mongodb-root-password}" | base64 --decode)
 
     kubectl -n "$NAMESPACE" exec "$MONGO_POD" -- mkdir -p /bitnami/mongodb/tmp/backups/
     kubectl -n "$NAMESPACE" cp -v=2 "$MONGO_BU" "$MONGO_POD":/bitnami/mongodb/tmp/backups/

--- a/migrate-3-to-4/mongo.sh
+++ b/migrate-3-to-4/mongo.sh
@@ -5,11 +5,11 @@ function import_mongo() {
 
     MONGO_POD="mongodb-0"
     MONGODB_USERNAME="root"
-    MONGODB_PASSWORD=$(kubectl -n "$NAMESPACE" get secrets mongodb -o jsonpath="{.data.mongodb-root-password}" | base64 --decode)
+    MONGODB_PASSWORD=$(kubectl -n "$NAMESPACE" get secrets mongodb-credentials -o jsonpath="{.data.mongodb-root-password}" | base64 --decode)
 
-    kubectl -n "$NAMESPACE" exec "$MONGO_POD" -- mkdir -p /tmp/backups/
-    kubectl -n "$NAMESPACE" cp -v=2 "$MONGO_BU" "$MONGO_POD":/tmp/backups/
+    kubectl -n "$NAMESPACE" exec "$MONGO_POD" -- mkdir -p /bitnami/mongodb/tmp/backups/
+    kubectl -n "$NAMESPACE" cp -v=2 "$MONGO_BU" "$MONGO_POD":/bitnami/mongodb/tmp/backups/
 
-    kubectl -n "$NAMESPACE" exec "$MONGO_POD" -- mongorestore --drop -u "$MONGODB_USERNAME" -p "$MONGODB_PASSWORD" --authenticationDatabase admin /tmp/backups/circle-mongo;
-    kubectl -n "$NAMESPACE" exec "$MONGO_POD" -- rm -rf /tmp/backups
+    kubectl -n "$NAMESPACE" exec "$MONGO_POD" -- mongorestore --drop -u "$MONGODB_USERNAME" -p "$MONGODB_PASSWORD" --authenticationDatabase admin /bitnami/mongodb/tmp/backups/circle-mongo
+    kubectl -n "$NAMESPACE" exec "$MONGO_POD" -- rm -rf /bitnami/mongodb/tmp
 }


### PR DESCRIPTION
:gear: **Issue**

With our installation, our mongo db was 17GB on disk, and 52GB in the export format.  Our data volume was expanded to 100GB previously, but there was no way the export would have fit into /tmp (only 50GB with 17GB in use).

:white_check_mark: **Fix**

This fix just uses the data volume which (in our case) already had the space available, but there is probably a better way to create a large temporary volume for the backup process.

:question: **Tests**

This code got us to 4.x. 😃 

- [ ] Tested Updating Existing Instance
- [ ] Installed on new instance
