### PR TITLE
feat: collect rabbitmq queue info

### DIFF
--- a/support/support-bundle.yaml
+++ b/support/support-bundle.yaml
@@ -27,6 +27,13 @@ spec:
       args: ["-c","nomad node status && echo && nomad server members && echo && nomad status"]
       timeout: 10s
   - exec:
+      name: rabbitmq-list-queues
+      selector:
+        - app.kubernetes.io/name=rabbitmq
+      command: ["/bin/sh"]
+      args: ["-c","rabbitmqctl list_queues"]
+      timeout: 10s
+  - exec:
       name: pvc-postgres
       selector:
         - app.kubernetes.io/name=postgresql


### PR DESCRIPTION
:gear: **Issue**

Given recent investigations for a Server customer re: RabbitMQ queue sizes increasing, I noted we do ask customers to run the following on their k8s cluster:

```console
# see https://www.rabbitmq.com/rabbitmqctl.8.html#list_queues
$ kubectl -n <namespace> exec rabbitmq-0 -- rabbitmqctl list_queues
```

:white_check_mark: **Fix**

I think it thus may be good to also include this information as part of the support bundle.
I added this command to be part of the data collectable for our support bundle manifest.

I think this command is not expensive to run, so it shouldn't be "taxing" on the k8s cluster 🤞 

:question: **Tests**

Verified on my Server 4.1.x instance:

<img width="1136" alt="Screenshot 2023-05-25 at 13 19 15" src="https://github.com/CircleCI-Public/server-scripts/assets/2164346/81b583f8-c1be-462d-b58b-ac98611e31c7">

