### PR TITLE
SERVER-2470 | remove dup logs

### DIFF
--- a/support/support-bundle.yaml
+++ b/support/support-bundle.yaml
@@ -6,18 +6,6 @@ spec:
   collectors:
   - clusterInfo: {}
   - clusterResources: {}
-  - logs:
-      selector:
-      - layer=application
-      name: application
-  - logs:
-      selector:
-      - layer=data
-      name: data
-  - logs:
-      selector:
-      - layer=execution
-      name: nomad
   - exec:
       name: nomad-status
       selector:


### PR DESCRIPTION
:gear: **Issue**

* Duplicate logs folder are increasing the size of support bundle if there are multiple replicas for each service 

:white_check_mark: **Fix**

* deleted the logs folder "application", "data" and "nomad" as all the logs are available under cluster-resources/pods/logs/ folder

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [ ] Tested Updating Existing Instance
- [ ] Installed on new instance
