### PR TITLE
Add note regarding prerequisites and scaling down pods

### DIFF
--- a/migrate-3-to-4/README.md
+++ b/migrate-3-to-4/README.md
@@ -6,6 +6,17 @@
 
 2. In the 3.4 environment, add the same [docker-registry secret](https://circleci.com/docs/server/installation/phase-2-core-services/#pull-images) that is used in the 4.0 environment
 
+3. Ensure that you have the prequisites outlined in the [docs](https://circleci.com/docs/server/installation/migrate-from-server-3-to-server-4/#prerequisites) page as well. Specifically the following:
+   - `kubectl`
+   - `yq`
+   - `helm`
+   - `helm-diff`
+  
+ 4. Scale down the application pods (This is just to ensure that no new data is being written to the databases during an export)
+```
+kubectl -n "$NAMESPACE" get deploy --no-headers -l "layer=application" | awk '{print $1}' | xargs -I echo -- kubectl -n "$NAMESPACE" scale deploy echo --replicas=0
+```
+
 ## Using
 `./exporter.sh` will export all the datastores from a 3.4 instance onto your local machine.  `./restore.sh` will import the data now on your local machine into the 4.0 environment
 


### PR DESCRIPTION
:gear: **Issue**

<!-- What's wrong; why the change? A good place to reference the ticket if it exists. -->

:white_check_mark: **Fix**

- Added prerequisites for the `migrate-3-to-4` script. I am aware that we might archive these soon but just want to make sure that these are captured so we don't forget some of the important steps required if we ever revisit these future. 

- Scaling down the application pods seems to be an important step for customers run the export script against > 50GB databases. 

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [x] Tested Updating Existing Instance
  - Encountered these during a live upgrade with a customer.
- [ ] Installed on new instance
