### PR TITLE
fix: Proceed with account context

### DIFF
--- a/vault-to-tink/import-contexts.sh
+++ b/vault-to-tink/import-contexts.sh
@@ -94,6 +94,10 @@ while read -r obj; do
     ((ORG_TOTAL=ORG_TOTAL+1))  # +1 total unique org counter
   fi
 
+  if [ "${org_id}" == "6ecee9e4-1c95-4e0d-8af3-5c57c35e84c8" ]; then
+    org_name="Account"
+  fi
+
   # if Org name is empty
   if [ -z "${org_name}" ] ; then
     if [ "${old_org_id}" != "${org_id}" ]; then


### PR DESCRIPTION
The account context ID of `6ecee9e4-1c95-4e0d-8af3-5c57c35e84c8` is hardcoded. It will never have an associated org, therefore we can just hardcode a name for it and move on.