### PR TITLE
vault-to-tink/import-contexts.sh URL Error When Importing Multiple Contexts

### DIFF
--- a/vault-to-tink/import-contexts.sh
+++ b/vault-to-tink/import-contexts.sh
@@ -119,7 +119,6 @@ while read -r obj; do
        ((EMPTY=EMPTY+1))
        continue
     fi
-    ctx=$(echo "${ctx}" | jq -c '.[]')
     # extract the name and value of the context
     name=$(echo "${ctx}" | jq -r '.["name"]')
     value=$(echo "${ctx}" | jq '.["value"]')
@@ -143,7 +142,7 @@ while read -r obj; do
     fi
     echo "context id: ${context_id} has imported (${HTTP_CODE}: ${RESPONSE})"
     ((SUCCESS=SUCCESS+1))
-  done < <(echo -n "${obj}" | jq -c '.["contexts"]')  # parsing contexts from each line object
+  done < <(echo -n "${obj}" | jq -c '.contexts[]')  # parsing contexts from each line object
 done < <(jq -c . "${INPUT_FILE}")  # reading input file
 
 # -------------------------- End: Processing Contexts ---------------------------------


### PR DESCRIPTION
:gear: **Issue**

<!-- What's wrong; why the change? A good place to reference the ticket if it exists. -->

user reported encountering an error while attempting to import multiple context variables using the import-script. The error message indicates a problem with the URL formatting, preventing the successful import of the contexts.

The issue stems from how multiple contexts are being handled in the script. When multiple contexts are present, they are not processed individually. Instead, they are read together, causing the URL to become malformed with concatenated context names.

```
++ curl -sS -o response.txt -w '%{http_code}' --request PUT --url 'https://<hostname>/api/v2/context/<context_id>/environment-variable/GITHUB_TOKEN
CIRCLE_TOKEN' --header 'Circle-Token: SECRET' --header 'Content-Type: application/json' --data '{"value":"GITHUB_TOKEN_VALUE"
"CCI_TOKEN_VALUE"}'

Org <org_id> ( sample ): processing
curl: (3) URL rejected: Malformed input to a URL function
context id: <context_id> has failed to import (000: )
```

And their contexts.json looked like following.
```
{"organization-ref":"<org_id>","context-id":"<context_id>","contexts":[{"name":"GITHUB_TOKEN","value":"GITHUB_TOKEN_VALUE"},{"name":"CIRCLE_TOKEN","value":"CCI_TOKEN_VALUE"}]}
```

:white_check_mark: **Fix**

Change script to correctly parse each context separately. This ensures that each context is processed individually, preventing the URL from becoming malformed.

- **Before the Fix:** The script was using `jq -c '.["contexts"]'` to parse the contexts, which treated the multiple contexts as a single entity. This caused the `curl` URL to receive multiple context names concatenated together, resulting in a malformed URL.
  
- **After the Fix:** The script now uses `jq -c '.contexts[]'` to iterate over each context individually. This ensures that each context is processed separately, generating a properly formatted URL for each environment variable.

<!-- How did you fix the issue? -->

:question: **Tests**

**Before the fix:**

From the output we can see that two values are imported to one env var.
```
log aaaa
AES : "aaaaaa"
"waaaaaa"
```

<img width="689" alt="Screenshot 2025-02-06 at 13 54 34" src="https://github.com/user-attachments/assets/7e3f7758-2b10-4208-ba33-369c172ee598" />


**After the fix**

```
log aaaa : "aaaaaa"
```

<img width="806" alt="Screenshot 2025-02-06 at 13 58 44" src="https://github.com/user-attachments/assets/c9b1371e-2e9e-46f7-86f7-c73f56ffe1de" />

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

