### PR TITLE
ONPREM-1485 | Fetch server version in support bundle

### DIFF
--- a/support/support-bundle.yaml
+++ b/support/support-bundle.yaml
@@ -68,6 +68,13 @@ spec:
       command: ["/bin/sh"]
       args: ["-c","df -h /bitnami/rabbitmq/mnesia"]
       timeout: 10s
+  - exec:
+      name: server-version
+      selector:
+        - app.kubernetes.io/name=rabbitmq
+      command: ["/bin/sh"]
+      args: ["-c","curl -k https://kong/version"]
+      timeout: 10s
   redactors:
   - name: Redact Object storage credentials
     fileSelector:


### PR DESCRIPTION
With k8s support bundle, we can fetch the deployed server version in directory `server-version`