### PR TITLE
Add exec to frontend pod to retrieve the server version

### DIFF
--- a/support/support-bundle.yaml
+++ b/support/support-bundle.yaml
@@ -75,6 +75,15 @@ spec:
       command: ["/bin/sh"]
       args: ["-c","curl -k https://kong/version"]
       timeout: 10s
+  - exec:
+      name: server-version
+      selector:
+      #Needs to be changed to www-api in 5.0
+      #Can also change to https:// at a later date
+        - app=frontend
+      command: ["/bin/sh"]
+      args: ["-c", "curl -s \"http://circleci-proxy-acm.$K8S_POD_NAMESPACE.svc.cluster.local/version\" || curl -s \"http://circleci-proxy.$K8S_POD_NAMESPACE.svc.cluster.local/version\""]
+      timeout: 10s
   redactors:
   - name: Redact Object storage credentials
     fileSelector:


### PR DESCRIPTION
:gear: **Issue**
To gain access to the server version, we have look at the charts provided with the bundle.

:white_check_mark: **Fix**
By execing into the frontend pod, we can retrieve access to the proxy allowing us to curl the version, even in airgapped environments.

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [ ] Tested Updating Existing Instance
- [ ] Installed on new instance
