### PR TITLE
Add Postgres 12→14 in-place upgrade script for CircleCI Server

### DIFF
--- a/upgrade-postgres-to-14/README.md
+++ b/upgrade-postgres-to-14/README.md
@@ -1,0 +1,265 @@
+# CircleCI Server: Postgres 12 → 14 upgrade script
+
+`upgrade-postgres-to-14.sh` automates the on-disk PostgreSQL major-version upgrade inside your CircleCI Server installation. It renders and applies a one-shot Kubernetes Job that runs `pg_upgrade --link` against your existing Postgres PVC, then prints the helm values block to update and the `helm upgrade` command to run.
+
+The full upgrade procedure — including platform-specific guidance on snapshots, rollback, and recovery — is documented separately at **docs.circleci.com** (CircleCI Server upgrade guide). This README focuses on operating the script and the end-to-end flow at a high level.
+
+## What the script does
+
+- Discovers your PVC name, postgres password secret, and (while postgres is still running) the source-cluster encoding/locale. Every value is overridable.
+- Verifies that your application-layer deployments are scaled to 0 before doing anything.
+- If the postgres StatefulSet is still running, captures encoding/locale from the live cluster and **scales postgres to 0** automatically, then waits for the underlying volume to detach.
+- Renders a `pg_upgrade` Job manifest, applies it, and streams the Job's logs.
+- Verifies completion by waiting for the Job's `Complete` condition.
+- On success, prints the helm values block to paste into your CircleCI Server values file and the exact `helm upgrade` command to run.
+
+## What the script does NOT do
+
+- **It does not take backups.** Snapshotting the PVC or pre-provisioning a PVC clone is your responsibility and platform-specific (CSI VolumeSnapshot, your cloud provider's snapshot CLI, Velero, etc.). The script assumes you have a known-good restore path before you invoke it.
+- **It does not scale your application layer.** You scale `layer=application` deployments to 0 before invoking the script. The script verifies this and refuses to proceed otherwise. (It does scale the postgres StatefulSet itself — see above.)
+- **It does not run `helm upgrade`.** That step is yours — the script tells you exactly what to run. The `helm upgrade` afterward restores replicas to their correct counts for both postgres and your application layer.
+
+## End-to-end upgrade procedure
+
+1. **Pre-flight.**
+   - Confirm your cluster can pull the target `server-postgres:14.22.x` image. By default the script pulls from CircleCI's ACR (`cciserver.azurecr.io`); use `--dockerhub` if you pull from Docker Hub.
+   - Decide on a rollback strategy: a point-in-time snapshot of the postgres PVC, or a pre-provisioned PVC clone, or both. *How* you take either depends on your platform — see the detailed upgrade guide on docs.circleci.com.
+   - Source-cluster encoding and locale: in the standard flow, the script captures these for you (it queries `template1` while postgres is still running, then scales postgres to 0 itself). You don't need to query manually. If you'd like to verify ahead of time:
+     ```
+     PGP=$(kubectl -n <ns> get secret <secret-name> \
+       -o jsonpath='{.data.postgres-password}' | base64 -d)
+     kubectl -n <ns> exec postgresql-0 -- env PGPASSWORD="$PGP" \
+       psql -U postgres -tAc \
+       "SELECT pg_encoding_to_char(encoding), datcollate, datctype \
+        FROM pg_database WHERE datname='template1'"
+     ```
+     The script's built-in defaults are `UTF8` / `C.UTF-8` / `C.UTF-8`. Common alternative locales are `en_US.UTF-8` for `LC_COLLATE` / `LC_CTYPE` on some Bitnami builds. If you prefer to scale postgres down yourself (instead of letting the script do it), capture these values *before* scaling and pass them to the script via:
+     ```
+     ./upgrade-postgres-to-14.sh -n <ns> \
+       --initdb-encoding <encoding> \
+       --initdb-lc-collate <lc_collate> \
+       --initdb-lc-ctype <lc_ctype>
+     ```
+     A locale or encoding mismatch causes `pg_upgrade` to abort partway through its consistency checks with an error naming the offending database and value.
+   - Plan a maintenance window. Total downtime depends on your database size, storage performance, the number of databases and extensions, and post-upgrade `VACUUM ANALYZE` time. We recommend at least 30-60 minutes.
+
+2. **Take a backup.** Snapshot the PVC, or pre-provision a clone PVC, or both. The remaining steps assume you can restore from one of these if anything goes wrong.
+
+3. **Quiesce the application layer.** Scale your application deployments to 0. Leave the postgres StatefulSet alone — the script will scale it down itself after capturing the live cluster's encoding/locale:
+   ```
+   kubectl -n <ns> scale deploy -l layer=application --replicas=0
+   ```
+   The script refuses to proceed if any `layer=application` deployment still has replicas > 0.
+
+4. **Run the upgrade.** With the application layer quiesced:
+   ```
+   ./upgrade-postgres-to-14.sh -n <namespace>
+   ```
+   See [Flags](#flags) for overrides. The script will:
+   - Query the live postgres pod for encoding/locale.
+   - Prompt to scale the postgres StatefulSet to 0, then wait for the underlying volume to detach (the cloud-side detach round-trip typically takes 30–90 seconds).
+   - Apply the `pg_upgrade` Job and stream its logs.
+   - Exit 0 once `pg_upgrade` reports `Upgrade Complete` and the new PG14 cluster is in place at `/bitnami/postgresql/data`.
+
+   If you'd rather scale postgres down yourself, do so before invoking the script — but capture encoding/locale *before* you scale, since the script can't query a stopped pod.
+
+5. **Update your helm values.** On success, the script prints the exact `postgresql:` block to paste into your CircleCI Server values file. The change is in the `postgresql.image` registry/repository/tag — for the default (ACR) run, the diff against the previous PG12 pin looks like:
+
+   ```diff
+    postgresql:
+      image:
+        registry: cciserver.azurecr.io
+        repository: circleci/server-postgres
+        tag: 14.22.4094-4922444
+   ```
+
+   If you ran the script with `--dockerhub`, `registry: docker.io` stays — only the `tag` changes.
+
+6. **Roll forward.** Run `helm upgrade` against your CircleCI Server release. This upgrades the chart, deploys the new postgres image, and restores correct replica counts for postgres and your application workloads — you don't need a separate scale-up:
+   ```
+   helm upgrade circleci-server \
+     oci://cciserver.azurecr.io/circleci-server \
+     --version <server-version> \
+     -f <path-to-your-values-file>
+   ```
+   The new postgres pod mounts the upgraded data directory and starts on PG14.
+
+7. **Validate.**
+   ```
+   PGP=$(kubectl -n <ns> get secret <secret-name> \
+     -o jsonpath='{.data.postgres-password}' | base64 -d)
+   kubectl -n <ns> exec -it postgresql-0 -- \
+     env PGPASSWORD="$PGP" psql -U postgres -c 'SELECT version();'
+   kubectl -n <ns> exec -it postgresql-0 -- \
+     env PGPASSWORD="$PGP" vacuumdb -U postgres --all --analyze-in-stages
+   ```
+   `pg_upgrade` does NOT carry optimizer statistics across — `vacuumdb --analyze-in-stages` rebuilds them and keeps query plans sane. Smoke-test your CircleCI install (log in, trigger a workflow) and watch the postgres logs for any startup warnings.
+
+8. **Clean up.** After at least 24 hours of healthy operation on PG14:
+   - Delete the completed upgrade Job (its pod has terminated, but the Job object stays in the namespace until you remove it):
+     ```
+     kubectl -n <ns> delete job postgres-upgrade-12-to-14
+     ```
+   - Inside the postgres pod, remove the old data directory left behind by `pg_upgrade`:
+     ```
+     kubectl -n <ns> exec -it postgresql-0 -- bash
+     # then, inside the pod:
+     bash /bitnami/postgresql/upgrade-logs/delete_old_cluster.sh
+     ```
+   - Delete your snapshot or pre-provisioned clone PVC if you no longer need them.
+
+## Quick start
+
+```bash
+# Standard install: everything auto-discovered, ACR by default
+./upgrade-postgres-to-14.sh -n circleci-server
+
+# Pull server-postgres from Docker Hub instead of ACR
+./upgrade-postgres-to-14.sh -n circleci-server --dockerhub
+
+# Use a newer PG14 tag than the script's default
+./upgrade-postgres-to-14.sh -n circleci-server -t 14.22.5000-newsha
+
+# Preview the rendered Job manifest without applying
+./upgrade-postgres-to-14.sh -n circleci-server --dry-run
+
+# Fully explicit, no confirmation prompts
+./upgrade-postgres-to-14.sh -n circleci-server \
+  --pvc-name data-postgresql-0 --secret-name postgresql \
+  --initdb-lc-collate en_US.UTF-8 --initdb-lc-ctype en_US.UTF-8 \
+  -y
+```
+
+## Flags
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `-n, --namespace NS` | *(required)* | Namespace where your postgres StatefulSet runs. |
+| `-t, --pg14-tag TAG` | `14.22.4094-4922444` | server-postgres image tag to upgrade to. |
+| `--pvc-name NAME` | auto-discovered | Source PVC. Defaults to whatever has `app.kubernetes.io/name=postgresql` in your namespace. |
+| `--secret-name NAME` | auto-discovered | Secret holding the postgres superuser password. |
+| `--secret-key KEY` | `postgres-password` | Key within that secret. |
+| `--initdb-encoding ENC` | discovered, else `UTF8` | New cluster encoding. |
+| `--initdb-lc-collate LOC` | discovered, else `C.UTF-8` | New cluster `LC_COLLATE`. Must match source. |
+| `--initdb-lc-ctype LOC` | discovered, else `C.UTF-8` | New cluster `LC_CTYPE`. Must match source. |
+| `--dockerhub` | off | Pull `server-postgres` from Docker Hub (`circleci/server-postgres`) instead of ACR. |
+| `--acr-path PATH` | `cciserver.azurecr.io/circleci/server-postgres` | Override the ACR repository path. |
+| `--upgrade-job-image IMG` | `tianon/postgres-upgrade:12-to-14` | Image used by the `pg_upgrade` Job itself (always pulled from Docker Hub). |
+| `-y, --yes` | off | Skip confirmation prompts. |
+| `--dry-run` | off | Render the Job manifest and exit without applying. |
+| `-h, --help` | — | Show usage. |
+
+## Prerequisites
+
+- `kubectl` configured for the target cluster (verify with `kubectl config current-context`).
+- A standard CircleCI Server internal installation of `postgresql`.
+- Network reachability from your cluster to the registry hosting the PG14 image (ACR by default), with `imagePullSecrets` configured accordingly.
+- Network reachability from your cluster to Docker Hub for the `tianon/postgres-upgrade:12-to-14` utility image used by the Job. If your cluster can't reach Docker Hub, mirror that image to your own registry and pass it via `--upgrade-job-image`.
+- Your application-layer deployments (`layer=application`) scaled to 0 before invocation — the script verifies this and refuses to proceed otherwise. The postgres StatefulSet does *not* need to be scaled in advance; the script handles that.
+
+## Auto-discovery behavior
+
+The script reads the cluster to fill in placeholder values, so a typical invocation needs only `--namespace`.
+
+- **PVC name and secret name** are looked up via the `app.kubernetes.io/name=postgresql` label.
+- **Encoding and locale** are queried from the live postgres pod's `template1` catalog when the script starts. Discovery happens *before* the script scales postgres down, so it succeeds in the standard flow. If you'd prefer to scale postgres down yourself before invoking the script, you must pass the values via flags — by the time the script runs, the pod is gone and discovery has no live cluster to query.
+
+If discovery fails or you scaled postgres down ahead of time and didn't pass flags, the script falls back to its built-in defaults (`UTF8` / `C.UTF-8` / `C.UTF-8`) and prints a warning. A mismatch with the source cluster's actual settings causes `pg_upgrade` to abort partway through its consistency checks — see [Pre-flight](#end-to-end-upgrade-procedure) (step 1) for how to override.
+
+## Image source defaults
+
+- **server-postgres image** defaults to `cciserver.azurecr.io/circleci/server-postgres:<tag>` from CircleCI's ACR. Use `--dockerhub` to pull `circleci/server-postgres:<tag>` from Docker Hub instead, or `--acr-path` to override the ACR path.
+- **pg_upgrade utility image** is `tianon/postgres-upgrade:12-to-14`, always pulled from Docker Hub regardless of `--dockerhub`. If your cluster cannot reach Docker Hub, mirror this image and pass `--upgrade-job-image` accordingly.
+
+## What success looks like
+
+The script prints the next-step block at the end of a successful run:
+
+```
+═══════════════════════════════════════════════════════════════════════════
+NEXT STEPS
+═══════════════════════════════════════════════════════════════════════════
+
+1. UPDATE your helm values file. Replace the postgresql block with:
+
+  postgresql:
+    image:
+      registry: cciserver.azurecr.io
+      repository: circleci/server-postgres
+      tag: 14.22.4094-4922444
+
+2. RUN helm upgrade ...
+3. VALIDATE ...
+4. AFTER ≥24h of healthy operation, clean up ...
+═══════════════════════════════════════════════════════════════════════════
+```
+
+After updating the values file, run `helm upgrade circleci-server oci://cciserver.azurecr.io/circleci-server --version <server-version> -f <path-to-your-values-file>` to roll forward. This single command rolls the chart, applies the new postgres image, and restores correct replica counts for postgres and your application workloads — no separate scale-up needed.
+
+## Troubleshooting
+
+### Re-running after a failed Job
+
+The Job's first step refuses to re-run if `data-12`, `data-14`, or `data-12.preupgrade` exist on the PVC. To recover, run a one-shot pod that mounts the PVC and resets the state:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pg-upgrade-cleanup
+  namespace: <your-namespace>
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+  containers:
+    - name: cleanup
+      image: busybox:latest
+      command:
+        - sh
+        - -c
+        - |
+          set -ex
+          cd /bitnami/postgresql
+          if [ -d data-12 ] && [ ! -e data ]; then mv data-12 data; fi
+          rm -rf data-14 upgrade-logs
+          chown -R 1001:1001 data
+      volumeMounts:
+        - name: data
+          mountPath: /bitnami/postgresql
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: <your-postgres-pvc>
+```
+
+Apply, wait for it to reach phase `Succeeded`, delete it, then re-run `upgrade-postgres-to-14.sh`.
+
+### Common pg_upgrade failures
+
+- **Locale mismatch** — `lc_collate values for database "<name>" do not match` aborts the consistency checks. Re-run with `--initdb-lc-collate` / `--initdb-lc-ctype` set to the source cluster's actual values.
+- **Missing extension build** — if your PG12 databases use extensions (e.g. `pg_stat_statements`, `pgcrypto`, `uuid-ossp`), the target PG14 image must include them. Catalog all extensions per database during pre-flight:
+  ```
+  for db in $(kubectl -n <ns> exec postgresql-0 -- env PGPASSWORD="$PGP" \
+      psql -U postgres -tAc \
+      "SELECT datname FROM pg_database WHERE datistemplate=false AND datname!='postgres'"); do
+    echo "=== $db ==="
+    kubectl -n <ns> exec postgresql-0 -- env PGPASSWORD="$PGP" \
+      psql -U postgres -d "$db" -c "SELECT extname, extversion FROM pg_extension"
+  done
+  ```
+- **Authentication failure connecting to source cluster** — confirm `POSTGRES_SECRET_NAME` and `POSTGRES_SECRET_KEY` are correct by running:
+  ```
+  PGP=$(kubectl -n <ns> get secret <secret-name> \
+    -o jsonpath='{.data.<secret-key>}' | base64 -d)
+  kubectl -n <ns> exec postgresql-0 -- env PGPASSWORD="$PGP" \
+    psql -U postgres -c 'SELECT 1'
+  ```
+  *before* quiescing the cluster.
+
+For anything outside these common cases — including rollback procedures — refer to the CircleCI Server upgrade guide on docs.circleci.com.
+
+## Where to go next
+
+The detailed customer-facing upgrade documentation (with platform-specific snapshot and PVC clone procedures, rollback playbooks, and the full troubleshooting reference) is on **docs.circleci.com** under the CircleCI Server upgrade guide.

--- a/upgrade-postgres-to-14/README.md
+++ b/upgrade-postgres-to-14/README.md
@@ -6,9 +6,10 @@ The full upgrade procedure — including platform-specific guidance on snapshots
 
 ## What the script does
 
-- Discovers your PVC name, postgres password secret, and (while postgres is still running) the source-cluster encoding/locale. Every value is overridable.
+- Discovers your PVC name, postgres password secret, and the source-cluster encoding/locale. Every value is overridable.
 - Verifies that your application-layer deployments are scaled to 0 before doing anything.
-- If the postgres StatefulSet is still running, captures encoding/locale from the live cluster and **scales postgres to 0** automatically, then waits for the underlying volume to detach.
+- If the postgres StatefulSet is running, captures encoding/locale from the live cluster and **scales postgres to 0** automatically, then waits for the underlying volume to detach.
+- If postgres is already at 0 and you did not supply all three `--initdb-*` flags, scales postgres back to 1 briefly to read the locale from `template1`, then returns it to 0. If postgres won't come back up the script hard-fails with a remediation message — see [Auto-discovery behavior](#auto-discovery-behavior).
 - Renders a `pg_upgrade` Job manifest, applies it, and streams the Job's logs.
 - Verifies completion by waiting for the Job's `Complete` condition.
 - On success, prints the helm values block to paste into your CircleCI Server values file and the exact `helm upgrade` command to run.
@@ -33,7 +34,7 @@ The full upgrade procedure — including platform-specific guidance on snapshots
        "SELECT pg_encoding_to_char(encoding), datcollate, datctype \
         FROM pg_database WHERE datname='template1'"
      ```
-     The script's built-in defaults are `UTF8` / `C.UTF-8` / `C.UTF-8`. Common alternative locales are `en_US.UTF-8` for `LC_COLLATE` / `LC_CTYPE` on some Bitnami builds. If you prefer to scale postgres down yourself (instead of letting the script do it), capture these values *before* scaling and pass them to the script via:
+     The script's built-in defaults are `UTF8` / `C.UTF-8` / `C.UTF-8`. Common alternative locales are `en_US.UTF-8` for `LC_COLLATE` / `LC_CTYPE` on some Bitnami builds. You don't have to capture these manually — if postgres is at 0 when the script starts, it bounces postgres back up briefly to read the locale itself. But if you'd rather skip the bounce, pass the values to the script:
      ```
      ./upgrade-postgres-to-14.sh -n <ns> \
        --initdb-encoding <encoding> \
@@ -61,7 +62,7 @@ The full upgrade procedure — including platform-specific guidance on snapshots
    - Apply the `pg_upgrade` Job and stream its logs.
    - Exit 0 once `pg_upgrade` reports `Upgrade Complete` and the new PG14 cluster is in place at `/bitnami/postgresql/data`.
 
-   If you'd rather scale postgres down yourself, do so before invoking the script — but capture encoding/locale *before* you scale, since the script can't query a stopped pod.
+   If you scaled postgres down ahead of time, the script will bounce it back to 1 briefly to read the locale before applying the Job — no manual capture needed. (Pass `--initdb-encoding` / `--initdb-lc-collate` / `--initdb-lc-ctype` if you want to skip the bounce.)
 
 5. **Update your helm values.** On success, the script prints the exact `postgresql:` block to paste into your CircleCI Server values file. The change is in the `postgresql.image` registry/repository/tag — for the default (ACR) run, the diff against the previous PG12 pin looks like:
 
@@ -159,9 +160,9 @@ The full upgrade procedure — including platform-specific guidance on snapshots
 The script reads the cluster to fill in placeholder values, so a typical invocation needs only `--namespace`.
 
 - **PVC name and secret name** are looked up via the `app.kubernetes.io/name=postgresql` label.
-- **Encoding and locale** are queried from the live postgres pod's `template1` catalog when the script starts. Discovery happens *before* the script scales postgres down, so it succeeds in the standard flow. If you'd prefer to scale postgres down yourself before invoking the script, you must pass the values via flags — by the time the script runs, the pod is gone and discovery has no live cluster to query.
+- **Encoding and locale** are queried from the live postgres pod's `template1` catalog when the script starts. Discovery happens *before* the script scales postgres down, so it succeeds in the standard flow. If postgres is already at 0 when the script starts (e.g. you scaled it down yourself), the script briefly scales it back to 1 just to read the locale, then returns it to 0 — so you don't need to remember to pass `--initdb-*` flags. If postgres won't come back up within 5 minutes, or `psql` against `template1` fails, the script hard-fails with a remediation message; re-run after fixing postgres, or pass `--initdb-encoding` / `--initdb-lc-collate` / `--initdb-lc-ctype` explicitly to skip discovery entirely.
 
-If discovery fails or you scaled postgres down ahead of time and didn't pass flags, the script falls back to its built-in defaults (`UTF8` / `C.UTF-8` / `C.UTF-8`) and prints a warning. A mismatch with the source cluster's actual settings causes `pg_upgrade` to abort partway through its consistency checks — see [Pre-flight](#end-to-end-upgrade-procedure) (step 1) for how to override.
+In the rarer case where postgres is running but the live `psql` query fails (e.g. wrong secret key), the script warns and falls back to its built-in defaults (`UTF8` / `C.UTF-8` / `C.UTF-8`). A mismatch with the source cluster's actual settings causes `pg_upgrade` to abort partway through its consistency checks — see [Pre-flight](#end-to-end-upgrade-procedure) (step 1) for how to override.
 
 ## Image source defaults
 

--- a/upgrade-postgres-to-14/README.md
+++ b/upgrade-postgres-to-14/README.md
@@ -95,11 +95,7 @@ The full upgrade procedure — including platform-specific guidance on snapshots
    ```
    `pg_upgrade` does NOT carry optimizer statistics across — `vacuumdb --analyze-in-stages` rebuilds them and keeps query plans sane. Smoke-test your CircleCI install (log in, trigger a workflow) and watch the postgres logs for any startup warnings.
 
-8. **Clean up.** After at least 24 hours of healthy operation on PG14:
-   - Delete the completed upgrade Job (its pod has terminated, but the Job object stays in the namespace until you remove it):
-     ```
-     kubectl -n <ns> delete job postgres-upgrade-12-to-14
-     ```
+8. **Clean up.** After at least 24 hours of healthy operation on PG14 (the upgrade Job auto-deletes 24h after completion via `ttlSecondsAfterFinished`, so no manual Job deletion is needed):
    - Inside the postgres pod, remove the old data directory left behind by `pg_upgrade`:
      ```
      kubectl -n <ns> exec -it postgresql-0 -- bash
@@ -155,7 +151,8 @@ The full upgrade procedure — including platform-specific guidance on snapshots
 - A standard CircleCI Server internal installation of `postgresql`.
 - Network reachability from your cluster to the registry hosting the PG14 image (ACR by default), with `imagePullSecrets` configured accordingly.
 - Network reachability from your cluster to Docker Hub for the `tianon/postgres-upgrade:12-to-14` utility image used by the Job. If your cluster can't reach Docker Hub, mirror that image to your own registry and pass it via `--upgrade-job-image`.
-- Your application-layer deployments (`layer=application`) scaled to 0 before invocation — the script verifies this and refuses to proceed otherwise. The postgres StatefulSet does *not* need to be scaled in advance; the script handles that.
+- Your application-layer workloads (`layer=application`, Deployments and StatefulSets) scaled to 0 before invocation — the script verifies this and refuses to proceed otherwise. The postgres StatefulSet does *not* need to be scaled in advance; the script handles that.
+- The target namespace does not enforce Pod Security `restricted` admission. The Job needs to run as root (UID 0) for a chown step that bridges the upgrade image's UID 999 and the chart's UID 1001. If your namespace has `pod-security.kubernetes.io/enforce=restricted`, the script will fail pre-flight with a remediation message (temporarily relax the label to `baseline`, run the upgrade, restore).
 
 ## Auto-discovery behavior
 

--- a/upgrade-postgres-to-14/upgrade-postgres-to-14.sh
+++ b/upgrade-postgres-to-14/upgrade-postgres-to-14.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 #
 # Automates the on-disk Postgres 12 → 14 upgrade for CircleCI Server.
-# - Auto-discovers PVC, secret, and (while postgres is up) source-cluster
-#   encoding/locale. Every value is overridable.
-# - If the postgres StatefulSet is still running when the script starts, it
-#   captures encoding/locale, then scales postgres to 0 and waits for the
-#   underlying volume to detach.
+# - Auto-discovers PVC, secret, and source-cluster encoding/locale. Every
+#   value is overridable.
+# - If the postgres StatefulSet is running, captures encoding/locale, then
+#   scales postgres to 0 and waits for the underlying volume to detach.
+# - If postgres is already at 0 and any --initdb-* flag is missing, briefly
+#   scales postgres back to 1 to query template1, then returns it to 0.
 # - Renders the pg_upgrade Job manifest, applies it, streams logs, and
 #   verifies completion via `kubectl wait --for=condition=Complete`.
 # - On success, prints the helm values block to update and reminds the
@@ -330,22 +331,36 @@ else
 fi
 
 # Postgres StatefulSet state determines what happens next:
-#   - Already at 0 → we proceed directly to applying the Job. Locale must
-#     come from flags or fall back to Job-script defaults.
 #   - Running → capture encoding/locale from the live cluster, then scale
 #     postgres to 0 before applying the Job.
+#   - Already at 0 → if any --initdb-* flag is missing, briefly scale postgres
+#     back to 1 to query template1, then let the standard scale-down path
+#     return it to 0. If postgres won't come up or the query fails, hard-fail
+#     with a remediation message — silently falling back to defaults caused
+#     a pg_upgrade locale-compat abort in earlier runs.
 SS_REPLICAS=$(kubectl -n "$NAMESPACE" get sts postgresql \
   -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "")
 POSTGRES_NEEDS_SCALE=false
+POSTGRES_BOUNCED=false
 if [[ "$SS_REPLICAS" == "0" ]]; then
   log "  postgres StatefulSet replicas: 0 (already quiesced)"
-  if [[ -z "$INITDB_ENCODING" && -z "$INITDB_LC_COLLATE" && -z "$INITDB_LC_CTYPE" ]]; then
-    warn "postgres is already at 0 — cannot auto-discover encoding/locale at this point."
-    warn "Job script defaults will apply: UTF8 / C.UTF-8 / C.UTF-8."
-    warn "If the source cluster uses different settings, pg_upgrade will fail at its locale-compat check."
-    warn "Re-run with --initdb-encoding / --initdb-lc-collate / --initdb-lc-ctype to override."
+  if [[ -n "$INITDB_ENCODING" && -n "$INITDB_LC_COLLATE" && -n "$INITDB_LC_CTYPE" ]]; then
+    log "  initdb (explicitly set):    encoding=$INITDB_ENCODING lc_collate=$INITDB_LC_COLLATE lc_ctype=$INITDB_LC_CTYPE"
   else
-    log "  initdb (explicitly set):    encoding=${INITDB_ENCODING:-<Job default UTF8>} lc_collate=${INITDB_LC_COLLATE:-<Job default C.UTF-8>} lc_ctype=${INITDB_LC_CTYPE:-<Job default C.UTF-8>}"
+    log "  initdb locale not fully specified — temporarily scaling postgres back to 1 to query template1"
+    if $DRY_RUN; then
+      warn "  dry-run: would scale postgres up, query locale, then scale it back down"
+    else
+      kubectl -n "$NAMESPACE" scale sts postgresql --replicas=1 >/dev/null
+      log "  waiting for postgresql-0 to be Ready..."
+      kubectl -n "$NAMESPACE" wait --for=condition=Ready pod/postgresql-0 --timeout=5m >/dev/null \
+        || die "postgres did not become Ready within 5m after scale-up. Either troubleshoot postgres, scale it up yourself and wait until Ready before re-running, or re-run with --initdb-encoding / --initdb-lc-collate / --initdb-lc-ctype set explicitly."
+      discover_locale \
+        || die "postgres came up but template1 locale query failed (auth or psql issue). Re-run with --initdb-encoding / --initdb-lc-collate / --initdb-lc-ctype set explicitly."
+      log "  initdb (discovered after bounce): encoding=$INITDB_ENCODING lc_collate=$INITDB_LC_COLLATE lc_ctype=$INITDB_LC_CTYPE"
+      POSTGRES_NEEDS_SCALE=true
+      POSTGRES_BOUNCED=true
+    fi
   fi
 else
   log "  postgres StatefulSet replicas: $SS_REPLICAS — script will capture locale, then scale it to 0"
@@ -383,7 +398,11 @@ if ! $DRY_RUN; then
   log "═══════════════════════════════════════════════════════════════════"
   log "Planned actions (no further prompts after this one):"
   if $POSTGRES_NEEDS_SCALE; then
-    log "  • Scale StatefulSet 'postgresql' to 0 (takes the database offline)"
+    if $POSTGRES_BOUNCED; then
+      log "  • Scale StatefulSet 'postgresql' back to 0 (was scaled up briefly to read locale)"
+    else
+      log "  • Scale StatefulSet 'postgresql' to 0 (takes the database offline)"
+    fi
     log "  • Wait for the underlying volume to detach"
   fi
   log "  • Apply pg_upgrade Job '$JOB_NAME' against PVC '$PVC_NAME'"

--- a/upgrade-postgres-to-14/upgrade-postgres-to-14.sh
+++ b/upgrade-postgres-to-14/upgrade-postgres-to-14.sh
@@ -1,0 +1,626 @@
+#!/usr/bin/env bash
+#
+# Automates the on-disk Postgres 12 → 14 upgrade for CircleCI Server.
+# - Auto-discovers PVC, secret, and (while postgres is up) source-cluster
+#   encoding/locale. Every value is overridable.
+# - If the postgres StatefulSet is still running when the script starts, it
+#   captures encoding/locale, then scales postgres to 0 and waits for the
+#   underlying volume to detach.
+# - Renders the pg_upgrade Job manifest, applies it, streams logs, and
+#   verifies completion via `kubectl wait --for=condition=Complete`.
+# - On success, prints the helm values block to update and reminds the
+#   operator to run `helm upgrade` manually.
+#
+# PREREQUISITES (operator's responsibility):
+#   - Application-layer deployments (label `layer=application`) scaled to 0.
+#     The script refuses to proceed if any are still running.
+#   - Snapshot or PVC clone of the source PVC (platform-specific).
+#
+# DOES NOT do: app-layer scale-down, snapshot, validation, or post-upgrade
+# cleanup. The `helm upgrade` after a successful run restores correct
+# replica counts for postgres and the application layer.
+#
+set -euo pipefail
+
+SCRIPT_NAME=$(basename "$0")
+
+# ============================================================================
+# Defaults (override via flags)
+# ============================================================================
+NAMESPACE=""
+PVC_NAME=""
+SECRET_NAME=""
+SECRET_KEY="postgres-password"
+PG14_TAG="14.22.4094-4922444"
+
+ACR_PATH="cciserver.azurecr.io/circleci/server-postgres"
+DOCKERHUB_PATH="circleci/server-postgres"
+USE_DOCKERHUB=false
+
+INITDB_ENCODING=""
+INITDB_LC_COLLATE=""
+INITDB_LC_CTYPE=""
+
+UPGRADE_JOB_IMAGE="tianon/postgres-upgrade:12-to-14"
+JOB_NAME="postgres-upgrade-12-to-14"
+
+ASSUME_YES=false
+DRY_RUN=false
+
+# ============================================================================
+# Helpers
+# ============================================================================
+if [ -t 1 ]; then
+  C_RED='\033[1;31m'; C_YEL='\033[1;33m'; C_CYA='\033[1;36m'; C_GRN='\033[1;32m'; C_OFF='\033[0m'
+else
+  C_RED=''; C_YEL=''; C_CYA=''; C_GRN=''; C_OFF=''
+fi
+
+log()  { printf "${C_CYA}[%s]${C_OFF} %s\n" "$SCRIPT_NAME" "$*" >&2; }
+ok()   { printf "${C_GRN}[%s]${C_OFF} %s\n" "$SCRIPT_NAME" "$*" >&2; }
+warn() { printf "${C_YEL}[%s] WARN:${C_OFF} %s\n" "$SCRIPT_NAME" "$*" >&2; }
+err()  { printf "${C_RED}[%s] ERROR:${C_OFF} %s\n" "$SCRIPT_NAME" "$*" >&2; }
+die()  { err "$@"; exit 1; }
+
+confirm() {
+  $ASSUME_YES && return 0
+  local prompt="$1"
+  local reply
+  read -r -p "$prompt [y/N] " reply
+  [[ "$reply" =~ ^[Yy]$ ]]
+}
+
+# ============================================================================
+# Usage
+# ============================================================================
+usage() {
+  cat <<EOF
+Usage: $SCRIPT_NAME --namespace NS [options]
+
+Automates Step 4 (Run pg_upgrade) of the postgres 12 → 14 runbook. Renders
+the Job manifest with auto-discovered cluster values, applies it, streams
+logs, and prints the helm values block to update on success.
+
+REQUIRED:
+  -n, --namespace NS            Namespace where the postgres StatefulSet runs
+
+OPTIONAL:
+  -t, --pg14-tag TAG            PG14 server-postgres image tag
+                                (default: $PG14_TAG)
+
+OPTIONAL — auto-discovered from a standard Bitnami install if omitted:
+      --pvc-name NAME           Source PVC (default: discovered via labels)
+      --secret-name NAME        K8s secret with postgres password (default: discovered)
+      --secret-key KEY          Key within the secret (default: $SECRET_KEY)
+      --initdb-encoding ENC     New cluster encoding (default: discovered from live cluster, else UTF8)
+      --initdb-lc-collate LOC   New cluster LC_COLLATE (default: discovered, else C.UTF-8)
+      --initdb-lc-ctype LOC     New cluster LC_CTYPE (default: discovered, else C.UTF-8)
+
+IMAGE SOURCE:
+      --dockerhub               Pull server-postgres from Docker Hub instead of ACR
+      --acr-path PATH           ACR repo path (default: $ACR_PATH)
+      --upgrade-job-image IMG   Image for the pg_upgrade Job
+                                (default: $UPGRADE_JOB_IMAGE)
+
+EXECUTION:
+  -y, --yes                     Skip confirmation prompts
+      --dry-run                 Print the rendered Job YAML and exit
+  -h, --help                    Show this help
+
+EXAMPLES:
+  $SCRIPT_NAME -n circleci-server
+  $SCRIPT_NAME -n circleci-server -t 14.22.0-othertag
+  $SCRIPT_NAME -n circleci-server --dockerhub
+  $SCRIPT_NAME -n circleci-server \\
+      --pvc-name data-postgresql-0 --secret-name my-postgres-secret \\
+      --initdb-lc-collate en_US.UTF-8 --initdb-lc-ctype en_US.UTF-8 -y
+EOF
+}
+
+# ============================================================================
+# Arg parsing
+# ============================================================================
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n|--namespace)         NAMESPACE="$2"; shift 2 ;;
+    -t|--pg14-tag)          PG14_TAG="$2"; shift 2 ;;
+        --pvc-name)         PVC_NAME="$2"; shift 2 ;;
+        --secret-name)      SECRET_NAME="$2"; shift 2 ;;
+        --secret-key)       SECRET_KEY="$2"; shift 2 ;;
+        --initdb-encoding)  INITDB_ENCODING="$2"; shift 2 ;;
+        --initdb-lc-collate) INITDB_LC_COLLATE="$2"; shift 2 ;;
+        --initdb-lc-ctype)  INITDB_LC_CTYPE="$2"; shift 2 ;;
+        --dockerhub)        USE_DOCKERHUB=true; shift ;;
+        --acr-path)         ACR_PATH="$2"; shift 2 ;;
+        --upgrade-job-image) UPGRADE_JOB_IMAGE="$2"; shift 2 ;;
+    -y|--yes)               ASSUME_YES=true; shift ;;
+        --dry-run)          DRY_RUN=true; shift ;;
+    -h|--help)              usage; exit 0 ;;
+    *) err "Unknown option: $1"; usage; exit 1 ;;
+  esac
+done
+
+[[ -z "$NAMESPACE" ]] && { usage; die "--namespace is required"; }
+[[ -z "$PG14_TAG"  ]] && die "--pg14-tag is empty (internal default was cleared?)"
+
+# ============================================================================
+# Resolve image source
+# ============================================================================
+if $USE_DOCKERHUB; then
+  POSTGRES_IMAGE_REPO="$DOCKERHUB_PATH"
+  IMAGE_SOURCE_LABEL="Docker Hub"
+else
+  POSTGRES_IMAGE_REPO="$ACR_PATH"
+  IMAGE_SOURCE_LABEL="ACR ($ACR_PATH)"
+fi
+FULL_POSTGRES_IMAGE="$POSTGRES_IMAGE_REPO:$PG14_TAG"
+
+# Split image repo into registry/repository for the helm values snippet.
+# Docker image-reference rules: the first segment is treated as a registry
+# hostname only if it contains a `.`, a `:`, or is exactly `localhost`.
+# Otherwise it's a Docker Hub username and the whole string is the repository
+# under docker.io.
+FIRST_SEGMENT="${POSTGRES_IMAGE_REPO%%/*}"
+if [[ "$FIRST_SEGMENT" == "$POSTGRES_IMAGE_REPO" ]]; then
+  # No slash at all, e.g. just "postgres"
+  POSTGRES_IMAGE_REGISTRY="docker.io"
+  POSTGRES_IMAGE_REPOSITORY="$POSTGRES_IMAGE_REPO"
+elif [[ "$FIRST_SEGMENT" == *.* || "$FIRST_SEGMENT" == *:* || "$FIRST_SEGMENT" == "localhost" ]]; then
+  # First segment is a registry hostname (e.g. cciserver.azurecr.io)
+  POSTGRES_IMAGE_REGISTRY="$FIRST_SEGMENT"
+  POSTGRES_IMAGE_REPOSITORY="${POSTGRES_IMAGE_REPO#*/}"
+else
+  # First segment is a Docker Hub user (e.g. circleci/server-postgres → docker.io / circleci/server-postgres)
+  POSTGRES_IMAGE_REGISTRY="docker.io"
+  POSTGRES_IMAGE_REPOSITORY="$POSTGRES_IMAGE_REPO"
+fi
+
+# ============================================================================
+# Auto-discovery
+# ============================================================================
+discover_single() {
+  # $1 = resource kind, $2 = label selector
+  local kind="$1" selector="$2"
+  local names
+  names=$(kubectl -n "$NAMESPACE" get "$kind" -l "$selector" \
+    -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
+  local count
+  count=$(echo "$names" | wc -w | tr -d ' ')
+  case "$count" in
+    0) return 1 ;;
+    1) echo "$names" ;;
+    *) err "Multiple $kind match '$selector' in '$NAMESPACE': $names"
+       err "Specify explicitly via the appropriate flag."
+       return 2 ;;
+  esac
+}
+
+discover_locale() {
+  # Returns 0 if locale info was discovered into INITDB_* vars, 1 otherwise.
+  local pgp info
+  pgp=$(kubectl -n "$NAMESPACE" get secret "$SECRET_NAME" \
+    -o jsonpath="{.data.$SECRET_KEY}" 2>/dev/null | base64 -d 2>/dev/null) || return 1
+  [[ -z "$pgp" ]] && return 1
+  info=$(kubectl -n "$NAMESPACE" exec postgresql-0 -- \
+    env PGPASSWORD="$pgp" psql -U postgres -tAc \
+    "SELECT pg_encoding_to_char(encoding) || '|' || datcollate || '|' || datctype FROM pg_database WHERE datname='template1'" \
+    2>/dev/null) || return 1
+  [[ -z "$info" || "$info" != *"|"* ]] && return 1
+  INITDB_ENCODING="${INITDB_ENCODING:-${info%%|*}}"
+  local tmp="${info#*|}"
+  INITDB_LC_COLLATE="${INITDB_LC_COLLATE:-${tmp%|*}}"
+  INITDB_LC_CTYPE="${INITDB_LC_CTYPE:-${tmp##*|}}"
+}
+
+log "Discovering defaults from namespace '$NAMESPACE'..."
+
+if [[ -z "$PVC_NAME" ]]; then
+  PVC_NAME=$(discover_single pvc 'app.kubernetes.io/name=postgresql') \
+    || die "Could not auto-discover PVC; pass --pvc-name"
+  log "  PVC:    $PVC_NAME (discovered)"
+else
+  log "  PVC:    $PVC_NAME"
+fi
+
+if [[ -z "$SECRET_NAME" ]]; then
+  SECRET_NAME=$(discover_single secret 'app.kubernetes.io/name=postgresql') \
+    || die "Could not auto-discover secret; pass --secret-name"
+  log "  Secret: $SECRET_NAME (discovered)"
+else
+  log "  Secret: $SECRET_NAME"
+fi
+log "  Secret key: $SECRET_KEY"
+
+# Locale discovery is deferred — it depends on whether the postgres pod is
+# still running when we get to the pre-check phase. If it is, we'll query
+# template1 there. If it's not, we'll either use the values passed via
+# flags or fall back to Job script defaults (UTF8 / C.UTF-8 / C.UTF-8).
+
+# ============================================================================
+# Pre-checks
+# ============================================================================
+log ""
+log "Pre-checks:"
+
+CURRENT_CTX=$(kubectl config current-context)
+log "  kubectl context: $CURRENT_CTX"
+
+kubectl get ns "$NAMESPACE" >/dev/null 2>&1 \
+  || die "Namespace '$NAMESPACE' does not exist in context '$CURRENT_CTX'"
+
+kubectl -n "$NAMESPACE" get pvc "$PVC_NAME" >/dev/null 2>&1 \
+  || die "PVC '$PVC_NAME' not found in namespace '$NAMESPACE'"
+
+kubectl -n "$NAMESPACE" get secret "$SECRET_NAME" >/dev/null 2>&1 \
+  || die "Secret '$SECRET_NAME' not found in namespace '$NAMESPACE'"
+
+SECRET_HAS_KEY=$(kubectl -n "$NAMESPACE" get secret "$SECRET_NAME" \
+  -o jsonpath="{.data.$SECRET_KEY}" 2>/dev/null)
+[[ -z "$SECRET_HAS_KEY" ]] && die "Secret '$SECRET_NAME' has no key '$SECRET_KEY'"
+
+# Application layer must already be scaled to 0 — they hold the postgres
+# connections that would block shutdown. The script leaves their quiesce to
+# the operator, but verifies it before doing anything else.
+APP_RUNNING=$(kubectl -n "$NAMESPACE" get deploy -l layer=application \
+  -o jsonpath='{range .items[?(@.spec.replicas>0)]}{.metadata.name}({.spec.replicas}) {end}' \
+  2>/dev/null)
+if [[ -n "$APP_RUNNING" ]]; then
+  if $DRY_RUN; then
+    log "  application deployments: still running ($APP_RUNNING) (would need to be 0 for a real run; dry-run continues)"
+  else
+    err "Application deployments (layer=application) are still running:"
+    err "  $APP_RUNNING"
+    err "Scale them down first:"
+    err "  kubectl -n $NAMESPACE scale deploy -l layer=application --replicas=0"
+    die "Application layer must be at replicas=0 before running this script"
+  fi
+else
+  log "  application deployments (layer=application): all at replicas=0 (good)"
+fi
+
+# Postgres StatefulSet state determines what happens next:
+#   - Already at 0 → we proceed directly to applying the Job. Locale must
+#     come from flags or fall back to Job-script defaults.
+#   - Running → capture encoding/locale from the live cluster, then scale
+#     postgres to 0 before applying the Job.
+SS_REPLICAS=$(kubectl -n "$NAMESPACE" get sts postgresql \
+  -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "")
+POSTGRES_NEEDS_SCALE=false
+if [[ "$SS_REPLICAS" == "0" ]]; then
+  log "  postgres StatefulSet replicas: 0 (already quiesced)"
+  if [[ -z "$INITDB_ENCODING" && -z "$INITDB_LC_COLLATE" && -z "$INITDB_LC_CTYPE" ]]; then
+    warn "postgres is already at 0 — cannot auto-discover encoding/locale at this point."
+    warn "Job script defaults will apply: UTF8 / C.UTF-8 / C.UTF-8."
+    warn "If the source cluster uses different settings, pg_upgrade will fail at its locale-compat check."
+    warn "Re-run with --initdb-encoding / --initdb-lc-collate / --initdb-lc-ctype to override."
+  else
+    log "  initdb (explicitly set):    encoding=${INITDB_ENCODING:-<Job default UTF8>} lc_collate=${INITDB_LC_COLLATE:-<Job default C.UTF-8>} lc_ctype=${INITDB_LC_CTYPE:-<Job default C.UTF-8>}"
+  fi
+else
+  log "  postgres StatefulSet replicas: $SS_REPLICAS — script will capture locale, then scale it to 0"
+  POSTGRES_NEEDS_SCALE=true
+  if [[ -z "$INITDB_ENCODING" || -z "$INITDB_LC_COLLATE" || -z "$INITDB_LC_CTYPE" ]]; then
+    if discover_locale 2>/dev/null; then
+      log "  initdb (discovered live):   encoding=$INITDB_ENCODING lc_collate=$INITDB_LC_COLLATE lc_ctype=$INITDB_LC_CTYPE"
+    else
+      warn "Could not query postgresql-0 for encoding/locale even though the pod appears up."
+      warn "Job script defaults will apply: UTF8 / C.UTF-8 / C.UTF-8."
+      warn "If those don't match the source, pg_upgrade will fail at its locale-compat check."
+    fi
+  else
+    log "  initdb (explicitly set):    encoding=$INITDB_ENCODING lc_collate=$INITDB_LC_COLLATE lc_ctype=$INITDB_LC_CTYPE"
+  fi
+fi
+
+# Existing Job? — only relevant when we're actually going to apply
+if ! $DRY_RUN; then
+  if kubectl -n "$NAMESPACE" get job "$JOB_NAME" >/dev/null 2>&1; then
+    warn "Job '$JOB_NAME' already exists in '$NAMESPACE'."
+    confirm "Delete it before proceeding?" || die "Aborted"
+    log "  Deleting existing Job..."
+    kubectl -n "$NAMESPACE" delete job "$JOB_NAME" --wait=true
+  fi
+fi
+
+# ============================================================================
+# Scale postgres to 0 if needed
+# ============================================================================
+if $POSTGRES_NEEDS_SCALE && ! $DRY_RUN; then
+  log ""
+  log "Scaling postgres StatefulSet to 0..."
+  confirm "Proceed with scaling postgres down? This takes the database offline." \
+    || die "Aborted"
+  kubectl -n "$NAMESPACE" scale sts postgresql --replicas=0
+  log "  waiting for postgresql-0 pod to terminate..."
+  kubectl -n "$NAMESPACE" wait --for=delete pod/postgresql-0 --timeout=5m
+
+  log "  waiting for volume to detach (cloud-side detach round-trip)..."
+  PV_FOR_SCALE=$(kubectl -n "$NAMESPACE" get pvc "$PVC_NAME" \
+    -o jsonpath='{.spec.volumeName}')
+  VA_FOR_SCALE=$(kubectl get volumeattachment \
+    -o jsonpath='{range .items[?(@.spec.source.persistentVolumeName=="'$PV_FOR_SCALE'")]}{.metadata.name}{end}' \
+    2>/dev/null || true)
+  if [[ -n "$VA_FOR_SCALE" ]]; then
+    kubectl wait --for=delete "volumeattachment/$VA_FOR_SCALE" --timeout=3m
+    log "  volume fully detached"
+  else
+    log "  no VolumeAttachment found; volume already detached"
+  fi
+fi
+
+# ============================================================================
+# Render YAML
+# ============================================================================
+render_yaml() {
+  cat <<HEADER
+# Rendered by $SCRIPT_NAME on $(date -u +%Y-%m-%dT%H:%M:%SZ)
+# Namespace:         $NAMESPACE
+# Source PVC:        $PVC_NAME
+# Secret:            $SECRET_NAME (key: $SECRET_KEY)
+# Target image:      $FULL_POSTGRES_IMAGE  [from $IMAGE_SOURCE_LABEL]
+# pg_upgrade image:  $UPGRADE_JOB_IMAGE
+# initdb defaults:   encoding=${INITDB_ENCODING:-<Job default UTF8>} lc_collate=${INITDB_LC_COLLATE:-<Job default C.UTF-8>} lc_ctype=${INITDB_LC_CTYPE:-<Job default C.UTF-8>}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: $JOB_NAME
+  namespace: $NAMESPACE
+  labels:
+    purpose: pg-major-upgrade
+    source-version: "12.16"
+    target-version: "14.22"
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres-upgrade
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
+      containers:
+        - name: pg-upgrade
+          image: $UPGRADE_JOB_IMAGE
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: $SECRET_NAME
+                  key: $SECRET_KEY
+HEADER
+
+  [[ -n "$INITDB_ENCODING" ]] && cat <<ENV_ENC
+            - name: INITDB_ENCODING
+              value: "$INITDB_ENCODING"
+ENV_ENC
+
+  [[ -n "$INITDB_LC_COLLATE" ]] && cat <<ENV_COLLATE
+            - name: INITDB_LC_COLLATE
+              value: "$INITDB_LC_COLLATE"
+ENV_COLLATE
+
+  [[ -n "$INITDB_LC_CTYPE" ]] && cat <<ENV_CTYPE
+            - name: INITDB_LC_CTYPE
+              value: "$INITDB_LC_CTYPE"
+ENV_CTYPE
+
+  # Quoted heredoc — $VARs inside stay literal so the in-container bash
+  # sees them properly. (Note: any value injected from outside MUST be
+  # done via separate sections, not inside this block.)
+  cat <<'BASH_BODY'
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -euo pipefail
+              PGROOT=/bitnami/postgresql
+              CUR=$PGROOT/data
+              OLD=$PGROOT/data-12
+              NEW=$PGROOT/data-14
+              ARCHIVED=$PGROOT/data-12.preupgrade
+              LOGS=$PGROOT/upgrade-logs
+              UPGRADE_UID=999
+              UPGRADE_GID=999
+              CHART_UID=1001
+              CHART_GID=1001
+
+              echo "==> [1/7] Verifying PG 12 cluster at $CUR"
+              if [[ ! -f "$CUR/PG_VERSION" ]]; then
+                echo "FATAL: $CUR/PG_VERSION not found."; exit 1
+              fi
+              VER=$(cat "$CUR/PG_VERSION")
+              if [[ "$VER" != "12" ]]; then
+                echo "FATAL: expected PG_VERSION=12, found '$VER'"; exit 1
+              fi
+              if [[ -d "$OLD" || -d "$NEW" || -d "$ARCHIVED" ]]; then
+                echo "FATAL: leftover dir(s) from a prior run found under $PGROOT."
+                ls -la "$PGROOT" || true
+                exit 1
+              fi
+
+              echo "==> [2/7] Staging directories and configs"
+              mv "$CUR" "$OLD"
+              mkdir -p "$NEW" "$LOGS"
+              chmod 0700 "$OLD" "$NEW"
+
+              if [[ ! -f "$OLD/postgresql.conf" ]]; then
+                echo "    injecting minimal postgresql.conf"
+                printf '%s\n' \
+                  '# Minimal postgresql.conf written by the pg_upgrade Job.' \
+                  '# pg_upgrade overrides connection settings via -c on pg_ctl.' \
+                  > "$OLD/postgresql.conf"
+              fi
+              if [[ ! -f "$OLD/pg_hba.conf" ]]; then
+                echo "    injecting minimal pg_hba.conf"
+                printf '%s\n' \
+                  '# Minimal pg_hba.conf written by the pg_upgrade Job.' \
+                  '# Trust local connections so pg_upgrade can read catalogs.' \
+                  'local all all trust' \
+                  'host  all all 127.0.0.1/32 trust' \
+                  'host  all all ::1/128      trust' \
+                  > "$OLD/pg_hba.conf"
+              fi
+
+              chown -R ${UPGRADE_UID}:${UPGRADE_GID} "$OLD" "$NEW" "$LOGS"
+
+              echo "==> [3/7] initdb new PG14 cluster"
+              INITDB_ENCODING="${INITDB_ENCODING:-UTF8}"
+              INITDB_LC_COLLATE="${INITDB_LC_COLLATE:-C.UTF-8}"
+              INITDB_LC_CTYPE="${INITDB_LC_CTYPE:-C.UTF-8}"
+              echo "    encoding=$INITDB_ENCODING lc_collate=$INITDB_LC_COLLATE lc_ctype=$INITDB_LC_CTYPE"
+              gosu postgres /usr/lib/postgresql/14/bin/initdb \
+                -D "$NEW" \
+                --encoding="$INITDB_ENCODING" \
+                --lc-collate="$INITDB_LC_COLLATE" \
+                --lc-ctype="$INITDB_LC_CTYPE"
+
+              echo "==> [4/7] Running pg_upgrade --link (jobs=4)"
+              cd "$LOGS"
+              gosu postgres /usr/lib/postgresql/14/bin/pg_upgrade \
+                --old-bindir=/usr/lib/postgresql/12/bin \
+                --new-bindir=/usr/lib/postgresql/14/bin \
+                --old-datadir="$OLD" \
+                --new-datadir="$NEW" \
+                --link \
+                --jobs=4
+
+              echo "==> [5/7] Verifying new cluster"
+              NEWVER=$(cat "$NEW/PG_VERSION")
+              if [[ "$NEWVER" != "14" ]]; then
+                echo "FATAL: new cluster PG_VERSION='$NEWVER', expected 14."; exit 1
+              fi
+
+              echo "==> [6/7] Swapping data dirs into place"
+              mv "$OLD" "$ARCHIVED"
+              mv "$NEW" "$CUR"
+
+              echo "==> [7/7] Restoring chart's uid:gid (${CHART_UID}:${CHART_GID}) on $CUR"
+              chown -R ${CHART_UID}:${CHART_GID} "$CUR"
+
+              echo "==> Done. PG 14 cluster is at $CUR."
+              ls -la "$PGROOT"
+              ls -la "$LOGS"
+BASH_BODY
+
+  cat <<FOOTER
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /bitnami/postgresql
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: $PVC_NAME
+FOOTER
+}
+
+YAML=$(render_yaml)
+
+# ============================================================================
+# Show + confirm + apply
+# ============================================================================
+log ""
+log "Rendered Job manifest:"
+echo ""
+printf '%s\n' "$YAML" | sed 's/^/  /'
+echo ""
+
+if $DRY_RUN; then
+  log "Dry-run mode — exiting without applying."
+  exit 0
+fi
+
+confirm "Apply this Job?" || die "Aborted"
+
+log ""
+log "Applying Job..."
+printf '%s\n' "$YAML" | kubectl -n "$NAMESPACE" apply -f -
+
+log "Waiting for pod to be created and ready..."
+kubectl -n "$NAMESPACE" wait --for=condition=Ready pod \
+  -l "job-name=$JOB_NAME" --timeout=2m 2>&1 || true
+sleep 3
+
+log "Streaming Job logs (the Job continues running even if you Ctrl-C the stream)..."
+echo ""
+kubectl -n "$NAMESPACE" logs -f "job/$JOB_NAME" 2>&1 || true
+echo ""
+
+# ============================================================================
+# Verify success
+# ============================================================================
+# `kubectl logs -f` returns the moment the pod terminates, but the Job
+# controller takes a beat to reconcile and update .status.succeeded.
+# Use `kubectl wait` for the Complete condition instead of polling
+# .status.succeeded directly — wait blocks until the condition is true
+# or times out.
+log ""
+log "Waiting for the Job controller to record completion..."
+if kubectl -n "$NAMESPACE" wait --for=condition=Complete \
+     "job/$JOB_NAME" --timeout=2m 2>/dev/null; then
+  SUCCEEDED=1
+else
+  SUCCEEDED=0
+fi
+FAILED=$(kubectl -n "$NAMESPACE" get job "$JOB_NAME" \
+  -o jsonpath='{.status.failed}' 2>/dev/null || echo "")
+
+if [[ "$SUCCEEDED" == "1" ]]; then
+  ok "pg_upgrade Job completed successfully."
+  cat <<EOF
+
+═══════════════════════════════════════════════════════════════════════════════
+NEXT STEPS
+═══════════════════════════════════════════════════════════════════════════════
+
+1. UPDATE your helm values file. Replace the postgresql block with:
+
+  postgresql:
+    image:
+      registry: $POSTGRES_IMAGE_REGISTRY
+      repository: $POSTGRES_IMAGE_REPOSITORY
+      tag: $PG14_TAG
+
+  (Bitnami's postgresql chart uses split registry/repository/tag fields.
+  If your chart wraps it differently, adapt — the full image reference is:
+  $FULL_POSTGRES_IMAGE)
+
+2. RUN helm upgrade with the updated values:
+
+  helm upgrade <release-name> <chart-path> -f <your-values-file>.yaml
+
+  The StatefulSet will roll with the new image and start against the
+  upgraded data directory at /bitnami/postgresql/data.
+
+3. VALIDATE once the new pod is Ready:
+
+  PGP=\$(kubectl -n $NAMESPACE get secret $SECRET_NAME \\
+    -o jsonpath='{.data.$SECRET_KEY}' | base64 -d)
+  kubectl -n $NAMESPACE exec -it postgresql-0 -- \\
+    env PGPASSWORD="\$PGP" psql -U postgres -c 'SELECT version();'
+  kubectl -n $NAMESPACE exec -it postgresql-0 -- \\
+    env PGPASSWORD="\$PGP" vacuumdb -U postgres --all --analyze-in-stages
+
+4. SCALE application deployments back up:
+
+  kubectl -n $NAMESPACE scale deploy -l layer=application --replicas=1
+  for d in \$(kubectl -n $NAMESPACE get deploy -l layer=application -o name); do
+    kubectl -n $NAMESPACE rollout status "\$d" --timeout=10m
+  done
+
+5. AFTER ≥24h of healthy operation, run the Step 7 cleanup from plan.md
+   (delete data-12.preupgrade, delete clone PVC if pre-provisioned,
+   delete the snapshot).
+═══════════════════════════════════════════════════════════════════════════════
+EOF
+  exit 0
+else
+  err "pg_upgrade Job did not complete successfully (succeeded='$SUCCEEDED' failed='$FAILED')."
+  err "See logs above for diagnostics. Do not blindly retry — the Job's leftover-dir check"
+  err "will refuse re-runs while data-12/data-14/upgrade-logs exist on the PVC."
+  err "Refer to plan.md 'Re-running after failure' for the cleanup procedure."
+  exit 1
+fi

--- a/upgrade-postgres-to-14/upgrade-postgres-to-14.sh
+++ b/upgrade-postgres-to-14/upgrade-postgres-to-14.sh
@@ -50,7 +50,7 @@ DRY_RUN=false
 # ============================================================================
 # Helpers
 # ============================================================================
-if [ -t 1 ]; then
+if [ -t 2 ]; then
   C_RED='\033[1;31m'; C_YEL='\033[1;33m'; C_CYA='\033[1;36m'; C_GRN='\033[1;32m'; C_OFF='\033[0m'
 else
   C_RED=''; C_YEL=''; C_CYA=''; C_GRN=''; C_OFF=''
@@ -62,13 +62,21 @@ warn() { printf "${C_YEL}[%s] WARN:${C_OFF} %s\n" "$SCRIPT_NAME" "$*" >&2; }
 err()  { printf "${C_RED}[%s] ERROR:${C_OFF} %s\n" "$SCRIPT_NAME" "$*" >&2; }
 die()  { err "$@"; exit 1; }
 
+validate() {
+  local label="$1" value="$2" regex="$3"
+  [[ "$value" =~ $regex ]] || die "Invalid $label value '$value' (must match $regex)"
+}
+
 confirm() {
   $ASSUME_YES && return 0
   local prompt="$1"
   local reply
   read -r -p "$prompt [y/N] " reply
-  [[ "$reply" =~ ^[Yy]$ ]]
+  [[ "$reply" =~ ^[Yy]([Ee][Ss])?$ ]]
 }
+
+command -v kubectl >/dev/null 2>&1 \
+  || die "kubectl is required and must be in PATH"
 
 # ============================================================================
 # Usage
@@ -143,6 +151,18 @@ done
 [[ -z "$NAMESPACE" ]] && { usage; die "--namespace is required"; }
 [[ -z "$PG14_TAG"  ]] && die "--pg14-tag is empty (internal default was cleared?)"
 
+# Validate user-supplied values before they reach kubectl invocations or the
+# rendered YAML. Auto-discovered values come from kubectl/psql output and are
+# trusted (k8s enforces DNS-1123 names; postgres uses C identifiers for
+# encoding/locale names).
+validate "--namespace"  "$NAMESPACE"  '^[a-z0-9][a-z0-9.-]*$'
+validate "--secret-key" "$SECRET_KEY" '^[A-Za-z0-9._-]+$'
+[[ -n "$PVC_NAME"          ]] && validate "--pvc-name"          "$PVC_NAME"          '^[a-z0-9][a-z0-9.-]*$'
+[[ -n "$SECRET_NAME"       ]] && validate "--secret-name"       "$SECRET_NAME"       '^[a-z0-9][a-z0-9.-]*$'
+[[ -n "$INITDB_ENCODING"   ]] && validate "--initdb-encoding"   "$INITDB_ENCODING"   '^[A-Za-z0-9._@-]+$'
+[[ -n "$INITDB_LC_COLLATE" ]] && validate "--initdb-lc-collate" "$INITDB_LC_COLLATE" '^[A-Za-z0-9._@-]+$'
+[[ -n "$INITDB_LC_CTYPE"   ]] && validate "--initdb-lc-ctype"   "$INITDB_LC_CTYPE"   '^[A-Za-z0-9._@-]+$'
+
 # ============================================================================
 # Resolve image source
 # ============================================================================
@@ -215,17 +235,23 @@ discover_locale() {
 log "Discovering defaults from namespace '$NAMESPACE'..."
 
 if [[ -z "$PVC_NAME" ]]; then
-  PVC_NAME=$(discover_single pvc 'app.kubernetes.io/name=postgresql') \
-    || die "Could not auto-discover PVC; pass --pvc-name"
-  log "  PVC:    $PVC_NAME (discovered)"
+  rc=0; PVC_NAME=$(discover_single pvc 'app.kubernetes.io/name=postgresql') || rc=$?
+  case "$rc" in
+    0) log "  PVC:    $PVC_NAME (discovered)" ;;
+    1) die "Could not auto-discover PVC; pass --pvc-name" ;;
+    *) exit 1 ;;
+  esac
 else
   log "  PVC:    $PVC_NAME"
 fi
 
 if [[ -z "$SECRET_NAME" ]]; then
-  SECRET_NAME=$(discover_single secret 'app.kubernetes.io/name=postgresql') \
-    || die "Could not auto-discover secret; pass --secret-name"
-  log "  Secret: $SECRET_NAME (discovered)"
+  rc=0; SECRET_NAME=$(discover_single secret 'app.kubernetes.io/name=postgresql') || rc=$?
+  case "$rc" in
+    0) log "  Secret: $SECRET_NAME (discovered)" ;;
+    1) die "Could not auto-discover secret; pass --secret-name" ;;
+    *) exit 1 ;;
+  esac
 else
   log "  Secret: $SECRET_NAME"
 fi
@@ -248,6 +274,22 @@ log "  kubectl context: $CURRENT_CTX"
 kubectl get ns "$NAMESPACE" >/dev/null 2>&1 \
   || die "Namespace '$NAMESPACE' does not exist in context '$CURRENT_CTX'"
 
+# Pod Security Admission: a namespace enforcing `restricted` will reject the
+# Job because it needs to run as root (UID 0) to bridge the upgrade image's
+# UID 999 and the chart's UID 1001 via chown.
+PSS_ENFORCE=$(kubectl get ns "$NAMESPACE" \
+  -o jsonpath='{.metadata.labels.pod-security\.kubernetes\.io/enforce}' 2>/dev/null)
+if [[ "$PSS_ENFORCE" == "restricted" ]]; then
+  err "Namespace '$NAMESPACE' enforces Pod Security 'restricted' admission."
+  err "The pg_upgrade Job needs to run as root (UID 0) for a chown step that"
+  err "bridges the upgrade image's UID 999 and the chart's UID 1001."
+  err "Remediation: temporarily relax the label before re-running, e.g.:"
+  err "  kubectl label ns $NAMESPACE pod-security.kubernetes.io/enforce=baseline --overwrite"
+  err "Restore the original label after the upgrade completes."
+  die "Pod Security 'restricted' enforcement blocks this Job"
+fi
+log "  Pod Security enforce label: ${PSS_ENFORCE:-<unset>}"
+
 kubectl -n "$NAMESPACE" get pvc "$PVC_NAME" >/dev/null 2>&1 \
   || die "PVC '$PVC_NAME' not found in namespace '$NAMESPACE'"
 
@@ -258,24 +300,33 @@ SECRET_HAS_KEY=$(kubectl -n "$NAMESPACE" get secret "$SECRET_NAME" \
   -o jsonpath="{.data.$SECRET_KEY}" 2>/dev/null)
 [[ -z "$SECRET_HAS_KEY" ]] && die "Secret '$SECRET_NAME' has no key '$SECRET_KEY'"
 
+kubectl -n "$NAMESPACE" get sts postgresql >/dev/null 2>&1 \
+  || die "StatefulSet 'postgresql' not found in namespace '$NAMESPACE' (this script targets the standard CircleCI Server install)"
+
 # Application layer must already be scaled to 0 — they hold the postgres
 # connections that would block shutdown. The script leaves their quiesce to
-# the operator, but verifies it before doing anything else.
-APP_RUNNING=$(kubectl -n "$NAMESPACE" get deploy -l layer=application \
+# the operator, but verifies it before doing anything else. Checks both
+# Deployments and StatefulSets (some app-layer workloads are STS).
+APP_DEPLOY_RUNNING=$(kubectl -n "$NAMESPACE" get deploy -l layer=application \
   -o jsonpath='{range .items[?(@.spec.replicas>0)]}{.metadata.name}({.spec.replicas}) {end}' \
   2>/dev/null)
+APP_STS_RUNNING=$(kubectl -n "$NAMESPACE" get sts -l layer=application \
+  -o jsonpath='{range .items[?(@.spec.replicas>0)]}{.metadata.name}({.spec.replicas}) {end}' \
+  2>/dev/null)
+APP_RUNNING=$(echo "$APP_DEPLOY_RUNNING $APP_STS_RUNNING" | tr -s ' ' | sed 's/^ //;s/ $//')
 if [[ -n "$APP_RUNNING" ]]; then
   if $DRY_RUN; then
-    log "  application deployments: still running ($APP_RUNNING) (would need to be 0 for a real run; dry-run continues)"
+    log "  application workloads: still running ($APP_RUNNING) (would need to be 0 for a real run; dry-run continues)"
   else
-    err "Application deployments (layer=application) are still running:"
+    err "Application workloads (layer=application) are still running:"
     err "  $APP_RUNNING"
     err "Scale them down first:"
     err "  kubectl -n $NAMESPACE scale deploy -l layer=application --replicas=0"
+    err "  kubectl -n $NAMESPACE scale sts -l layer=application --replicas=0"
     die "Application layer must be at replicas=0 before running this script"
   fi
 else
-  log "  application deployments (layer=application): all at replicas=0 (good)"
+  log "  application workloads (layer=application): all at replicas=0 (good)"
 fi
 
 # Postgres StatefulSet state determines what happens next:
@@ -312,7 +363,9 @@ else
   fi
 fi
 
-# Existing Job? — only relevant when we're actually going to apply
+# Existing Job? — only relevant when we're actually going to apply. This is
+# a surprise (operator didn't expect a leftover), so it gets its own confirm
+# separate from the consolidated "planned actions" prompt below.
 if ! $DRY_RUN; then
   if kubectl -n "$NAMESPACE" get job "$JOB_NAME" >/dev/null 2>&1; then
     warn "Job '$JOB_NAME' already exists in '$NAMESPACE'."
@@ -323,13 +376,29 @@ if ! $DRY_RUN; then
 fi
 
 # ============================================================================
+# Consolidated confirmation — one prompt covers every planned action below
+# ============================================================================
+if ! $DRY_RUN; then
+  log ""
+  log "═══════════════════════════════════════════════════════════════════"
+  log "Planned actions (no further prompts after this one):"
+  if $POSTGRES_NEEDS_SCALE; then
+    log "  • Scale StatefulSet 'postgresql' to 0 (takes the database offline)"
+    log "  • Wait for the underlying volume to detach"
+  fi
+  log "  • Apply pg_upgrade Job '$JOB_NAME' against PVC '$PVC_NAME'"
+  log "  • Stream Job logs and wait for completion"
+  log "═══════════════════════════════════════════════════════════════════"
+  log ""
+  confirm "Proceed with all of the above?" || die "Aborted"
+fi
+
+# ============================================================================
 # Scale postgres to 0 if needed
 # ============================================================================
 if $POSTGRES_NEEDS_SCALE && ! $DRY_RUN; then
   log ""
   log "Scaling postgres StatefulSet to 0..."
-  confirm "Proceed with scaling postgres down? This takes the database offline." \
-    || die "Aborted"
   kubectl -n "$NAMESPACE" scale sts postgresql --replicas=0
   log "  waiting for postgresql-0 pod to terminate..."
   kubectl -n "$NAMESPACE" wait --for=delete pod/postgresql-0 --timeout=5m
@@ -341,7 +410,7 @@ if $POSTGRES_NEEDS_SCALE && ! $DRY_RUN; then
     -o jsonpath='{range .items[?(@.spec.source.persistentVolumeName=="'"$PV_FOR_SCALE"'")]}{.metadata.name}{end}' \
     2>/dev/null || true)
   if [[ -n "$VA_FOR_SCALE" ]]; then
-    kubectl wait --for=delete "volumeattachment/$VA_FOR_SCALE" --timeout=3m
+    kubectl wait --for=delete "volumeattachment/$VA_FOR_SCALE" --timeout=10m
     log "  volume fully detached"
   else
     log "  no VolumeAttachment found; volume already detached"
@@ -368,10 +437,11 @@ metadata:
   namespace: $NAMESPACE
   labels:
     purpose: pg-major-upgrade
-    source-version: "12.16"
+    source-major: "12"
     target-version: "14.22"
 spec:
   backoffLimit: 0
+  ttlSecondsAfterFinished: 86400
   template:
     metadata:
       labels:
@@ -507,6 +577,13 @@ ENV_CTYPE
 BASH_BODY
 
   cat <<FOOTER
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi
           volumeMounts:
             - name: postgres-data
               mountPath: /bitnami/postgresql
@@ -524,16 +601,14 @@ YAML=$(render_yaml)
 # ============================================================================
 log ""
 log "Rendered Job manifest:"
-echo ""
-printf '%s\n' "$YAML" | sed 's/^/  /'
-echo ""
+echo "" >&2
+printf '%s\n' "$YAML" | sed 's/^/  /' >&2
+echo "" >&2
 
 if $DRY_RUN; then
   log "Dry-run mode — exiting without applying."
   exit 0
 fi
-
-confirm "Apply this Job?" || die "Aborted"
 
 log ""
 log "Applying Job..."
@@ -541,13 +616,13 @@ printf '%s\n' "$YAML" | kubectl -n "$NAMESPACE" apply -f -
 
 log "Waiting for pod to be created and ready..."
 kubectl -n "$NAMESPACE" wait --for=condition=Ready pod \
-  -l "job-name=$JOB_NAME" --timeout=2m 2>&1 || true
+  -l "job-name=$JOB_NAME" --timeout=10m 2>&1 || true
 sleep 3
 
 log "Streaming Job logs (the Job continues running even if you Ctrl-C the stream)..."
-echo ""
+echo "" >&2
 kubectl -n "$NAMESPACE" logs -f "job/$JOB_NAME" 2>&1 || true
-echo ""
+echo "" >&2
 
 # ============================================================================
 # Verify success
@@ -560,7 +635,7 @@ echo ""
 log ""
 log "Waiting for the Job controller to record completion..."
 if kubectl -n "$NAMESPACE" wait --for=condition=Complete \
-     "job/$JOB_NAME" --timeout=2m 2>/dev/null; then
+     "job/$JOB_NAME" --timeout=10m 2>/dev/null; then
   SUCCEEDED=1
 else
   SUCCEEDED=0
@@ -570,16 +645,15 @@ FAILED=$(kubectl -n "$NAMESPACE" get job "$JOB_NAME" \
 
 if [[ "$SUCCEEDED" == "1" ]]; then
   ok "pg_upgrade Job completed successfully."
-  cat <<EOF
+  cat >&2 <<EOF
 
 ═══════════════════════════════════════════════════════════════════════════════
 NEXT STEPS
 ═══════════════════════════════════════════════════════════════════════════════
 
-1. UPDATE your helm values file. Replace the postgresql block with:
+1. UPDATE your helm values file. Ensure the following three fields under
+   postgresql.image are set to:
 
-  postgresql:
-    image:
       registry: $POSTGRES_IMAGE_REGISTRY
       repository: $POSTGRES_IMAGE_REPOSITORY
       tag: $PG14_TAG
@@ -590,7 +664,10 @@ NEXT STEPS
 
 2. RUN helm upgrade with the updated values:
 
-  helm upgrade <release-name> <chart-path> -f <your-values-file>.yaml
+  helm upgrade circleci-server \\
+    oci://cciserver.azurecr.io/circleci-server \\
+    --version <server-version> \\
+    -f <path-to-your-values-file>
 
   The StatefulSet will roll with the new image and start against the
   upgraded data directory at /bitnami/postgresql/data.
@@ -611,9 +688,11 @@ NEXT STEPS
     kubectl -n $NAMESPACE rollout status "\$d" --timeout=10m
   done
 
-5. AFTER ≥24h of healthy operation, run the Step 7 cleanup from plan.md
-   (delete data-12.preupgrade, delete clone PVC if pre-provisioned,
-   delete the snapshot).
+5. AFTER ≥24h of healthy operation, complete the cleanup steps from
+   README → "Clean up" (step 8): delete the data-12.preupgrade dir inside
+   the postgres pod, delete your snapshot, and delete the clone PVC if
+   you pre-provisioned one. (The upgrade Job auto-deletes 24h after
+   completion via ttlSecondsAfterFinished.)
 ═══════════════════════════════════════════════════════════════════════════════
 EOF
   exit 0
@@ -621,6 +700,6 @@ else
   err "pg_upgrade Job did not complete successfully (succeeded='$SUCCEEDED' failed='$FAILED')."
   err "See logs above for diagnostics. Do not blindly retry — the Job's leftover-dir check"
   err "will refuse re-runs while data-12/data-14/upgrade-logs exist on the PVC."
-  err "Refer to plan.md 'Re-running after failure' for the cleanup procedure."
+  err "See README.md → 'Re-running after a failed Job' for the cleanup procedure."
   exit 1
 fi

--- a/upgrade-postgres-to-14/upgrade-postgres-to-14.sh
+++ b/upgrade-postgres-to-14/upgrade-postgres-to-14.sh
@@ -338,7 +338,7 @@ if $POSTGRES_NEEDS_SCALE && ! $DRY_RUN; then
   PV_FOR_SCALE=$(kubectl -n "$NAMESPACE" get pvc "$PVC_NAME" \
     -o jsonpath='{.spec.volumeName}')
   VA_FOR_SCALE=$(kubectl get volumeattachment \
-    -o jsonpath='{range .items[?(@.spec.source.persistentVolumeName=="'$PV_FOR_SCALE'")]}{.metadata.name}{end}' \
+    -o jsonpath='{range .items[?(@.spec.source.persistentVolumeName=="'"$PV_FOR_SCALE"'")]}{.metadata.name}{end}' \
     2>/dev/null || true)
   if [[ -n "$VA_FOR_SCALE" ]]; then
     kubectl wait --for=delete "volumeattachment/$VA_FOR_SCALE" --timeout=3m


### PR DESCRIPTION
upgrade-postgres-to-14.sh renders and applies a one-shot pg_upgrade --link Job against the existing postgres PVC, then prints the helm values block and helm upgrade command operators need to roll forward.

The script auto-discovers PVC, secret, and source-cluster encoding/locale, verifies the application layer is scaled to 0, scales the postgres StatefulSet down itself, and streams Job logs until the Complete condition is observed. Defaults pull from ACR; --dockerhub switches to Docker Hub. Flags cover encoding/locale overrides, custom tags, and dry-run rendering.

README documents the full end-to-end procedure (snapshot, quiesce, run, helm upgrade, validate, clean up), what the script intentionally does NOT do (backups, app-layer scaling, helm upgrade), and troubleshooting for the common pg_upgrade failure modes — locale mismatch, missing extensions, re-running after a failed Job.

[ONPREM-3305](https://circleci.atlassian.net/browse/ONPREM-3305)

:gear: **Issue**

<!-- What's wrong; why the change? A good place to reference the ticket if it exists. -->

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [ ] Tested Updating Existing Instance
- [ ] Installed on new instance


[ONPREM-3305]: https://circleci.atlassian.net/browse/ONPREM-3305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ