### PR TITLE
Default pg_upgrade Job image to ACR, Docker Hub only via --dockerhub

### DIFF
--- a/upgrade-postgres-to-14/README.md
+++ b/upgrade-postgres-to-14/README.md
@@ -139,9 +139,9 @@ The full upgrade procedure — including platform-specific guidance on snapshots
 | `--initdb-encoding ENC` | discovered, else `UTF8` | New cluster encoding. |
 | `--initdb-lc-collate LOC` | discovered, else `C.UTF-8` | New cluster `LC_COLLATE`. Must match source. |
 | `--initdb-lc-ctype LOC` | discovered, else `C.UTF-8` | New cluster `LC_CTYPE`. Must match source. |
-| `--dockerhub` | off | Pull `server-postgres` from Docker Hub (`circleci/server-postgres`) instead of ACR. |
+| `--dockerhub` | off | Pull both the `server-postgres` image (`circleci/server-postgres`) and the `pg_upgrade` Job image (`circleci/server-postgres-upgrade:12-14`) from Docker Hub instead of ACR. |
 | `--acr-path PATH` | `cciserver.azurecr.io/circleci/server-postgres` | Override the ACR repository path. |
-| `--upgrade-job-image IMG` | `tianon/postgres-upgrade:12-to-14` | Image used by the `pg_upgrade` Job itself (always pulled from Docker Hub). |
+| `--upgrade-job-image IMG` | `cciserver.azurecr.io/server-postgres-upgrade:12-14` (ACR), or `circleci/server-postgres-upgrade:12-14` with `--dockerhub` | Image used by the `pg_upgrade` Job itself. |
 | `-y, --yes` | off | Skip confirmation prompts. |
 | `--dry-run` | off | Render the Job manifest and exit without applying. |
 | `-h, --help` | — | Show usage. |
@@ -151,7 +151,7 @@ The full upgrade procedure — including platform-specific guidance on snapshots
 - `kubectl` configured for the target cluster (verify with `kubectl config current-context`).
 - A standard CircleCI Server internal installation of `postgresql`.
 - Network reachability from your cluster to the registry hosting the PG14 image (ACR by default), with `imagePullSecrets` configured accordingly.
-- Network reachability from your cluster to Docker Hub for the `tianon/postgres-upgrade:12-to-14` utility image used by the Job. If your cluster can't reach Docker Hub, mirror that image to your own registry and pass it via `--upgrade-job-image`.
+- Network reachability from your cluster to the registry hosting the `pg_upgrade` Job image — by default `cciserver.azurecr.io/server-postgres-upgrade:12-14` from ACR, or `circleci/server-postgres-upgrade:12-14` from Docker Hub with `--dockerhub`. If your cluster can't reach either, mirror that image to your own registry and pass it via `--upgrade-job-image`.
 - Your application-layer workloads (`layer=application`, Deployments and StatefulSets) scaled to 0 before invocation — the script verifies this and refuses to proceed otherwise. The postgres StatefulSet does *not* need to be scaled in advance; the script handles that.
 - The target namespace does not enforce Pod Security `restricted` admission. The Job needs to run as root (UID 0) for a chown step that bridges the upgrade image's UID 999 and the chart's UID 1001. If your namespace has `pod-security.kubernetes.io/enforce=restricted`, the script will fail pre-flight with a remediation message (temporarily relax the label to `baseline`, run the upgrade, restore).
 
@@ -167,7 +167,7 @@ In the rarer case where postgres is running but the live `psql` query fails (e.g
 ## Image source defaults
 
 - **server-postgres image** defaults to `cciserver.azurecr.io/circleci/server-postgres:<tag>` from CircleCI's ACR. Use `--dockerhub` to pull `circleci/server-postgres:<tag>` from Docker Hub instead, or `--acr-path` to override the ACR path.
-- **pg_upgrade utility image** is `tianon/postgres-upgrade:12-to-14`, always pulled from Docker Hub regardless of `--dockerhub`. If your cluster cannot reach Docker Hub, mirror this image and pass `--upgrade-job-image` accordingly.
+- **pg_upgrade utility image** defaults to `cciserver.azurecr.io/server-postgres-upgrade:12-14` from CircleCI's ACR. Use `--dockerhub` to pull `circleci/server-postgres-upgrade:12-14` from Docker Hub instead, or `--upgrade-job-image` to point at any other registry (e.g. a mirror).
 
 ## What success looks like
 

--- a/upgrade-postgres-to-14/upgrade-postgres-to-14.sh
+++ b/upgrade-postgres-to-14/upgrade-postgres-to-14.sh
@@ -38,11 +38,17 @@ ACR_PATH="cciserver.azurecr.io/circleci/server-postgres"
 DOCKERHUB_PATH="circleci/server-postgres"
 USE_DOCKERHUB=false
 
+# pg_upgrade Job image. Defaults to ACR; --dockerhub switches it to Docker Hub.
+# An explicit --upgrade-job-image overrides both (UPGRADE_JOB_IMAGE starts empty
+# so we can tell whether the operator set it).
+ACR_UPGRADE_IMAGE="cciserver.azurecr.io/server-postgres-upgrade:12-14"
+DOCKERHUB_UPGRADE_IMAGE="circleci/server-postgres-upgrade:12-14"
+
 INITDB_ENCODING=""
 INITDB_LC_COLLATE=""
 INITDB_LC_CTYPE=""
 
-UPGRADE_JOB_IMAGE="circleci/server-postgres-upgrade:12-to-14"
+UPGRADE_JOB_IMAGE=""
 JOB_NAME="postgres-upgrade-12-to-14"
 
 ASSUME_YES=false
@@ -109,7 +115,8 @@ IMAGE SOURCE:
       --dockerhub               Pull server-postgres from Docker Hub instead of ACR
       --acr-path PATH           ACR repo path (default: $ACR_PATH)
       --upgrade-job-image IMG   Image for the pg_upgrade Job
-                                (default: $UPGRADE_JOB_IMAGE)
+                                (default: $ACR_UPGRADE_IMAGE;
+                                 $DOCKERHUB_UPGRADE_IMAGE with --dockerhub)
 
 EXECUTION:
   -y, --yes                     Skip confirmation prompts
@@ -169,9 +176,11 @@ validate "--secret-key" "$SECRET_KEY" '^[A-Za-z0-9._-]+$'
 # ============================================================================
 if $USE_DOCKERHUB; then
   POSTGRES_IMAGE_REPO="$DOCKERHUB_PATH"
+  UPGRADE_JOB_IMAGE="${UPGRADE_JOB_IMAGE:-$DOCKERHUB_UPGRADE_IMAGE}"
   IMAGE_SOURCE_LABEL="Docker Hub"
 else
   POSTGRES_IMAGE_REPO="$ACR_PATH"
+  UPGRADE_JOB_IMAGE="${UPGRADE_JOB_IMAGE:-$ACR_UPGRADE_IMAGE}"
   IMAGE_SOURCE_LABEL="ACR ($ACR_PATH)"
 fi
 FULL_POSTGRES_IMAGE="$POSTGRES_IMAGE_REPO:$PG14_TAG"


### PR DESCRIPTION
## Summary

- Make the `pg_upgrade` Job image default to ACR (`cciserver.azurecr.io/server-postgres-upgrade:12-14`) and switch to Docker Hub (`circleci/server-postgres-upgrade:12-14`) only when `--dockerhub` is passed — mirroring how the `server-postgres` image already behaves. An explicit `--upgrade-job-image` still overrides both.
- Update the earlier commit that pointed the Job image at the `circleci/...` Docker Hub repo so the registry is now flag-driven rather than hardcoded.
- Refresh the README (flags table, prerequisites, image-source defaults), which still documented the stale `tianon/postgres-upgrade:12-to-14` image as "always from Docker Hub."

## Test plan

- `bash -n` and `shellcheck` pass on the script.
- `--help` shows both the ACR default and the `--dockerhub` variant for `--upgrade-job-image`.
- Verified image resolution for all four cases: default → ACR, `--dockerhub` → Docker Hub, explicit `--upgrade-job-image` wins with and without `--dockerhub`.
- Remaining cluster-dependent check (run `--dry-run` against a test namespace and confirm the rendered manifest's `image:` and `# pg_upgrade image:` header match) left for the reviewer/operator.