### PR TITLE
feat: add namespace-scoped support bundle with wrapper script

### DIFF
--- a/support/README.md
+++ b/support/README.md
@@ -1,30 +1,39 @@
-# CircleCI Helm Chart Support Bundle
-This directory contains a support bundle for troubleshoot.sh. It allows users to collect and sanitize information about a specific install, to send to support for additional debugging.
+# CircleCI Server Support Bundle
 
-The manifests defined in this directory are client-side, and install no resources on the cluster.
+This directory contains support bundle configs for [troubleshoot.sh](https://troubleshoot.sh). They collect and sanitize diagnostic information from a CircleCI Server install to share with the support team.
 
+The manifests defined here are client-side and install no resources on the cluster.
 
 ## Prerequisites
 
-1. First, make sure circleci-server is deployed and you have access to the cluster/namespace through kubectl.
-2. Next, [install krew](https://krew.sigs.k8s.io/docs/user-guide/setup/install/).
-
-
-3. Install preflight and support bundle to your local development machine.
+1. Make sure CircleCI Server is deployed and you have access to the cluster via `kubectl`. For the namespace-scoped bundle, your kubeconfig must have `get`/`list` permissions on pods, logs, deployments, and events in the target namespace, plus cluster-level read access for `clusterResources`.
+2. [Install krew](https://krew.sigs.k8s.io/docs/user-guide/setup/install/).
+3. Install the support-bundle plugin:
 
 ```bash
-kubectl krew install preflight
 kubectl krew install support-bundle
 ```
 
-## Collecting Support Information (Development)
+## Collecting Support Information
 
-### Collecting Information
-When ready, run the support bundle from the current directory and wait for it to finish.
+### Namespace-scoped (recommended)
+
+Use `run.sh` to collect data from a specific namespace. Defaults to `circleci-server`:
 
 ```bash
-# Within the server/support directory
-kubectl support-bundle support-bundle.yaml
+# From the repo root
+./support/run.sh
+
+# Custom namespace
+./support/run.sh my-namespace
 ```
 
-A sanitized .tar.gz file will be created in the current directory - this can be sent to the support team for further debugging.
+### Cluster-wide
+
+To collect from all namespaces (useful when the install namespace is unknown):
+
+```bash
+kubectl support-bundle support/support-bundle.yaml
+```
+
+A sanitized `.tar.gz` will be created in the current directory. Attach it to your support ticket.

--- a/support/run.sh
+++ b/support/run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="${1:-circleci-server}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+sed \
+  -e "s/namespace: circleci-server/namespace: ${NAMESPACE}/g" \
+  -e "s/- circleci-server$/- ${NAMESPACE}/" \
+  "${SCRIPT_DIR}/support-bundle-namespaced.yaml" \
+  | kubectl support-bundle -

--- a/support/support-bundle-namespaced.yaml
+++ b/support/support-bundle-namespaced.yaml
@@ -1,0 +1,306 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: circleci-server
+spec:
+  collectors:
+  - clusterInfo: {}
+  - clusterResources:
+      namespaces:
+        - circleci-server
+  - logs:
+      selector:
+      - layer=application
+      name: application
+      namespace: circleci-server
+  - logs:
+      selector:
+      - layer=data
+      name: data
+      namespace: circleci-server
+  - logs:
+      selector:
+      - layer=execution
+      name: nomad
+      namespace: circleci-server
+  - exec:
+      name: nomad-status
+      selector:
+        - app=nomad-server
+        - layer=execution
+      namespace: circleci-server
+      command: ["/bin/sh"]
+      args: ["-c","nomad node status && echo && nomad server members && echo && nomad status"]
+      timeout: 10s
+  - exec:
+      name: rabbitmq-list-queues
+      selector:
+        - app.kubernetes.io/name=rabbitmq
+      namespace: circleci-server
+      command: ["/bin/sh"]
+      args: ["-c","rabbitmqctl list_queues"]
+      timeout: 10s
+  - exec:
+      name: pvc-postgres
+      selector:
+        - app.kubernetes.io/name=postgresql
+      namespace: circleci-server
+      command: ["/bin/sh"]
+      args: ["-c","df -h /bitnami/postgresql"]
+      timeout: 10s
+  - exec:
+      name: pvc-mongodb
+      selector:
+        - app.kubernetes.io/name=mongodb
+      namespace: circleci-server
+      command: ["/bin/sh"]
+      args: ["-c","df -h /bitnami/mongodb"]
+      timeout: 10s
+  - exec:
+      name: mongodb-diagnostic-data-compress
+      selector:
+        - app.kubernetes.io/name=mongodb
+      namespace: circleci-server
+      command: ["/bin/sh"]
+      args:
+        - "-c"
+        - |
+          mkdir -p /tmp/diagnostic.data && \
+          cp /bitnami/mongodb/data/db/diagnostic.data/metrics.interim /tmp/diagnostic.data/metrics.interim && \
+          find /bitnami/mongodb/data/db/diagnostic.data -name 'metrics.*' ! -name 'metrics.interim' | sort | tail -2 | xargs -I{} cp {} /tmp/diagnostic.data/ && \
+          tar czf /tmp/mongo-diagnostic.tar.gz -C /tmp diagnostic.data
+      timeout: 120s
+  - copy:
+      name: mongodb-diagnostic-data
+      selector:
+        - app.kubernetes.io/name=mongodb
+      namespace: circleci-server
+      containerPath: /tmp/mongo-diagnostic.tar.gz
+  - exec:
+      name: pvc-vault
+      selector:
+        - app=vault
+      namespace: circleci-server
+      command: ["/bin/sh"]
+      args: ["-c","df -h /vault/file"]
+      timeout: 10s
+  - exec:
+      name: pvc-redis
+      selector:
+        - app=redis
+      namespace: circleci-server
+      command: ["/bin/sh"]
+      args: ["-c","df -h /data"]
+      timeout: 10s
+  - exec:
+      name: pvc-rabbitmq
+      selector:
+        - app.kubernetes.io/name=rabbitmq
+      namespace: circleci-server
+      command: ["/bin/sh"]
+      args: ["-c","df -h /bitnami/rabbitmq/mnesia"]
+      timeout: 10s
+  - exec:
+      name: server-version
+      selector:
+        - app.kubernetes.io/name=rabbitmq
+      namespace: circleci-server
+      command: ["/bin/sh"]
+      args: ["-c","curl -k https://kong/version"]
+      timeout: 10s
+  - exec:
+      name: server-version
+      selector:
+      #Needs to be changed to www-api in 5.0
+      #Can also change to https:// at a later date
+        - app=frontend
+      namespace: circleci-server
+      command: ["/bin/sh"]
+      args: ["-c", "curl -s \"http://circleci-proxy-acm.$K8S_POD_NAMESPACE.svc.cluster.local/version\" || curl -s \"http://circleci-proxy.$K8S_POD_NAMESPACE.svc.cluster.local/version\""]
+      timeout: 10s
+  redactors:
+  - name: Redact Object storage credentials
+    fileSelector:
+      files:
+      - cluster-resources/pods/*.json
+      - cluster-resources/deployments/*.json
+    removals:
+      regex:
+      - selector: __ACCESS_KEY
+        redactor: '("value": ")(?P<mask>.*)(")'
+      - selector: __SECRET_KEY
+        redactor: '("value": ")(?P<mask>.*)(")'
+      - selector: AWS_ACCESS_KEY_ID
+        redactor: '("value": ")(?P<mask>.*)(")'
+      - selector: AWS_SECRET_ACCESS_KEY
+        redactor: '("value": ")(?P<mask>.*)(")'
+
+  - name: Redact ring session encryption key
+    fileSelector:
+      files:
+      - cluster-resources/pods/*.json
+      - cluster-resources/deployments/*.json
+    removals:
+      regex:
+      - selector: CIRCLE_SECRETS__SESSION_COOKIE_KEY
+        redactor: '("value": ")(?P<mask>.*)(")'
+
+  - name: Redact Github OAuth credentials
+    fileSelector:
+      files:
+      - cluster-resources/pods/*.json
+      - cluster-resources/deployments/*.json
+    removals:
+      regex:
+      - selector: CLIENT_ID
+        redactor: '("value": ")(?P<mask>.*)(")'
+      - selector: CLIENT_SECRET
+        redactor: '("value": ")(?P<mask>.*)(")'
+
+  - name: Redact soketi secret
+    fileSelector:
+      files:
+      - cluster-resources/pods/*.json
+      - cluster-resources/deployments/*.json
+    removals:
+      regex:
+      - selector: PUSHER__SECRET
+        redactor: '("value": ")(?P<mask>.*)(")'
+      - selector: DEFAULT_APP_SECRET
+        redactor: '("value": ")(?P<mask>.*)(")'
+
+  - name: keyczar encryption and signing keys
+    fileSelector:
+      files:
+      - cluster-resources/pods/*.json
+      - cluster-resources/deployments/*.json
+    removals:
+      regex:
+      - selector: KEYSET__
+        redactor: '("value": ")(?P<mask>.*)(")'
+      - selector: __KEYSET
+        redactor: '("value": ")(?P<mask>.*)(")'
+      - selector: JSON_WEB_KEYS
+        redactor: '("value": ")(?P<mask>.*)(")'
+
+  - name: Redact database passwords
+    fileSelector:
+      files:
+      - cluster-resources/pods/*.json
+      - cluster-resources/deployments/*.json
+    removals:
+      regex:
+      - selector: PGPASSWORD
+        redactor: '("value": ")(?P<mask>.*)(")'
+      - selector: _PASSWORD
+        redactor: '("value": ")(?P<mask>.*)(")'
+      - selector: __PASSWORD
+        redactor: '("value": ")(?P<mask>.*)(")'
+      - selector: SMTP__PASS
+        redactor: '("value": ")(?P<mask>.*)(")'
+
+  - name: Redact API and service tokens
+    fileSelector:
+      files:
+      - cluster-resources/pods/*.json
+      - cluster-resources/deployments/*.json
+    removals:
+      regex:
+      - selector: _TOKEN
+        redactor: '("value": ")(?P<mask>.*)(")'
+      - selector: __TOKEN
+        redactor: '("value": ")(?P<mask>.*)(")'
+
+  - name: Redact encryption keys, passphrases, and salts
+    fileSelector:
+      files:
+      - cluster-resources/pods/*.json
+      - cluster-resources/deployments/*.json
+    removals:
+      regex:
+      - selector: ENCRYPTION_KEY
+        redactor: '("value": ")(?P<mask>.*)(")'
+      - selector: ENCRYPT_KEY
+        redactor: '("value": ")(?P<mask>.*)(")'
+      - selector: PASSPHRASE
+        redactor: '("value": ")(?P<mask>.*)(")'
+      - selector: _SALT
+        redactor: '("value": ")(?P<mask>.*)(")'
+      - selector: SALTS__
+        redactor: '("value": ")(?P<mask>.*)(")'
+
+  - name: Redact Pusher/soketi app keys
+    fileSelector:
+      files:
+      - cluster-resources/pods/*.json
+      - cluster-resources/deployments/*.json
+    removals:
+      regex:
+      - selector: DEFAULT_APP_KEY
+        redactor: '("value": ")(?P<mask>.*)(")'
+      - selector: PUSHER_APP_KEY
+        redactor: '("value": ")(?P<mask>.*)(")'
+      - selector: PUSHER__KEY
+        redactor: '("value": ")(?P<mask>.*)(")'
+
+  - name: Redact third-party API keys and TLS private keys
+    fileSelector:
+      files:
+      - cluster-resources/pods/*.json
+      - cluster-resources/deployments/*.json
+    removals:
+      regex:
+      - selector: SEGMENT_API_KEY
+        redactor: '("value": ")(?P<mask>.*)(")'
+      - selector: API_KEY
+        redactor: '("value": ")(?P<mask>.*)(")'
+      - selector: SSL_CERT_KEY
+        redactor: '("value": ")(?P<mask>.*)(")'
+
+  - name: Redact Authorization and cookie headers in logs
+    removals:
+      regex:
+      - redactor: '(?i)(Authorization"?\s*[:=]\s*"?)(?P<mask>(Bearer\s+|Basic\s+)?[A-Za-z0-9._\-+/=]+)'
+      - redactor: '(?i)(X-Api-Token"?\s*[:=]\s*"?)(?P<mask>[A-Za-z0-9._\-+/=]+)'
+      - redactor: '(?i)(Circle-Token"?\s*[:=]\s*"?)(?P<mask>[A-Za-z0-9._\-+/=]+)'
+      - redactor: '(?i)((Set-)?Cookie"?\s*[:=]\s*"?)(?P<mask>[^"\r\n]+)'
+
+  # Removes passwords from URI's of the form <scheme>://<user>:<password>@<host>:<port>
+  - name: Redact passwords from URIs
+    fileSelector:
+      files:
+      - cluster-resources/pods/*.json
+      - cluster-resources/deployments/*.json
+    removals:
+      regex:
+      - redactor: '(?P<value>"value": ")(?P<scheme>[^:]*)(://)(?P<user>[^:]*)(:)(?P<mask>[^@]*)@(?P<hostname>[^(:|/)]*)(?P<rest>.*)(")'
+
+  # JDBC URI's put the password in the query string of the URI instead of the
+  # user information section of the URI. This removes password=<password>
+  # structured parts
+  - name: Redact passwords from JDBC URIs
+    fileSelector:
+      files:
+      - cluster-resources/pods/*.json
+      - cluster-resources/deployments/*.json
+    removals:
+      regex:
+      - redactor: '(?P<key>password=)(?P<mask>.*)'
+
+  # An annotation on deployments holds the previously applied configuration. It contains much
+  # of the environment variable section from the deployment but JSON escaped which can make the
+  # default redactions fail. We redact the entire annotation here to avoid leakage.
+  - name: last applied configuration annotation
+    removals:
+      regex:
+      - redactor: '("kubectl\.kubernetes\.io/last-applied-configuration": ")(?P<mask>.+)(")'
+
+  # Mask <local>@<label1>.<label2> only. For plain 2-level emails this masks the
+  # whole address. For SSH remotes (git@github.example.net) and service hostnames
+  # (rabbit@rabbitmq-0.rabbitmq-headless.svc.cluster.local) the additional labels
+  # past the first two stay visible for debugging.
+  - name: Redact customer employee email addresses in logs
+    removals:
+      regex:
+      - redactor: '(?P<mask>[A-Za-z0-9._%+\-]+@[A-Za-z0-9\-]+\.[A-Za-z0-9\-]+)'
+  analyzers: []


### PR DESCRIPTION
## Summary

- Adds `support/support-bundle-namespaced.yaml` — a copy of the cluster-wide config with `namespace: circleci-server` scoped on all collectors (`clusterResources`, `logs`, `exec`, `copy`)
- Adds `support/run.sh` — wrapper that accepts an optional namespace argument (defaults to `circleci-server`), substitutes it into the namespaced config via `sed`, and pipes to `kubectl support-bundle -`
- Updates `support/README.md` with both usage paths and RBAC requirements

## Why a wrapper script

Two simpler approaches were tried and ruled out:

**`$NAMESPACE` env var in the YAML** — troubleshoot.sh v0.106.0 does not expand OS environment variables in spec field values. The literal string `$NAMESPACE` was passed to the Kubernetes API, which found no matching namespace and silently returned empty results for every collector.

**`kubectl support-bundle -n <namespace>`** — the `-n` flag scopes where the spec is loaded from (Secret/ConfigMap), not collector operations. Running with `-n circleci-server` still pulled logs from all namespaces.

The only reliable mechanism is hardcoding the namespace directly in the spec. The wrapper script keeps the value configurable at runtime without requiring the user to edit the YAML.

## Test plan

- [x] Run `./support/run.sh` — confirm bundle output scoped to `circleci-server` namespace
- [x] Run `./support/run.sh my-namespace` — confirm bundle output scoped to custom namespace
- [x] Run `kubectl support-bundle support/support-bundle.yaml` — confirm cluster-wide collection still works
- [x] Verify `cluster-resources/pods/<namespace>.json` is non-empty in the output

Closes ONP-3477